### PR TITLE
Mobile flutter

### DIFF
--- a/apps/mobile/ios/Flutter/Generated.xcconfig
+++ b/apps/mobile/ios/Flutter/Generated.xcconfig
@@ -1,0 +1,15 @@
+// This is a generated file; do not edit or check into version control.
+FLUTTER_ROOT=C:\Users\hp\develop\flutter
+FLUTTER_APPLICATION_PATH=D:\UniLearn\UniLearn\apps\mobile
+FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=D:\UniLearn\UniLearn\apps\mobile\ios\Flutter\ephemeral\Packages\.packages\FlutterFramework
+COCOAPODS_PARALLEL_CODE_SIGN=true
+FLUTTER_TARGET=lib\main.dart
+FLUTTER_BUILD_DIR=build
+FLUTTER_BUILD_NAME=1.0.0
+FLUTTER_BUILD_NUMBER=1
+EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386
+EXCLUDED_ARCHS[sdk=iphoneos*]=armv7
+DART_OBFUSCATION=false
+TRACK_WIDGET_CREATION=true
+TREE_SHAKE_ICONS=false
+PACKAGE_CONFIG=.dart_tool/package_config.json

--- a/apps/mobile/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+++ b/apps/mobile/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+// Generated file. Do not edit.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "FlutterGeneratedPluginSwiftPackage",
+    platforms: [
+        .iOS("13.0")
+    ],
+    products: [
+        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+    ],
+    dependencies: [
+        
+    ],
+    targets: [
+        .target(
+            name: "FlutterGeneratedPluginSwiftPackage"
+        )
+    ]
+)

--- a/apps/mobile/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Sources/FlutterGeneratedPluginSwiftPackage/FlutterGeneratedPluginSwiftPackage.swift
+++ b/apps/mobile/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Sources/FlutterGeneratedPluginSwiftPackage/FlutterGeneratedPluginSwiftPackage.swift
@@ -1,0 +1,3 @@
+//
+// Generated file. Do not edit.
+//

--- a/apps/mobile/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/apps/mobile/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/apps/mobile/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/apps/mobile/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/apps/mobile/ios/Flutter/ephemeral/flutter_native_integration.env
+++ b/apps/mobile/ios/Flutter/ephemeral/flutter_native_integration.env
@@ -1,0 +1,12 @@
+FLUTTER_ROOT=C:\Users\hp\develop\flutter
+FLUTTER_APPLICATION_PATH=D:\UniLearn\UniLearn\apps\mobile
+FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=D:\UniLearn\UniLearn\apps\mobile\ios\Flutter\ephemeral\Packages\.packages\FlutterFramework
+COCOAPODS_PARALLEL_CODE_SIGN=true
+FLUTTER_TARGET=lib\main.dart
+FLUTTER_BUILD_DIR=build
+FLUTTER_BUILD_NAME=1.0.0
+FLUTTER_BUILD_NUMBER=1
+DART_OBFUSCATION=false
+TRACK_WIDGET_CREATION=true
+TREE_SHAKE_ICONS=false
+PACKAGE_CONFIG=.dart_tool/package_config.json

--- a/apps/mobile/ios/Flutter/flutter_export_environment.sh
+++ b/apps/mobile/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=C:\Users\hp\develop\flutter"
+export "FLUTTER_APPLICATION_PATH=D:\UniLearn\UniLearn\apps\mobile"
+export "FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=D:\UniLearn\UniLearn\apps\mobile\ios\Flutter\ephemeral\Packages\.packages\FlutterFramework"
+export "COCOAPODS_PARALLEL_CODE_SIGN=true"
+export "FLUTTER_TARGET=lib\main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "DART_OBFUSCATION=false"
+export "TRACK_WIDGET_CREATION=true"
+export "TREE_SHAKE_ICONS=false"
+export "PACKAGE_CONFIG=.dart_tool/package_config.json"

--- a/apps/mobile/ios/Runner/GeneratedPluginRegistrant.h
+++ b/apps/mobile/ios/Runner/GeneratedPluginRegistrant.h
@@ -1,0 +1,19 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GeneratedPluginRegistrant_h
+#define GeneratedPluginRegistrant_h
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GeneratedPluginRegistrant : NSObject
++ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry;
+@end
+
+NS_ASSUME_NONNULL_END
+#endif /* GeneratedPluginRegistrant_h */

--- a/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
+++ b/apps/mobile/ios/Runner/GeneratedPluginRegistrant.m
@@ -1,0 +1,21 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#import "GeneratedPluginRegistrant.h"
+
+#if __has_include(<shared_preferences_foundation/SharedPreferencesPlugin.h>)
+#import <shared_preferences_foundation/SharedPreferencesPlugin.h>
+#else
+@import shared_preferences_foundation;
+#endif
+
+@implementation GeneratedPluginRegistrant
+
++ (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
+  [SharedPreferencesPlugin registerWithRegistrar:[registry registrarForPlugin:@"SharedPreferencesPlugin"]];
+}
+
+@end

--- a/apps/mobile/lib/core/providers/auth_session_provider.dart
+++ b/apps/mobile/lib/core/providers/auth_session_provider.dart
@@ -36,11 +36,12 @@ final class AuthSessionNotifier extends Notifier<AuthSessionState> {
   Future<void> signInWithMockCredentials({
     required String email,
     required String password,
+    String? name,
   }) async {
     final user = AuthUser(
       id: 'mock-user-1',
       email: email,
-      name: _displayNameFromEmail(email),
+      name: _displayNameFromInput(name) ?? _displayNameFromEmail(email),
       role: 'STUDENT',
     );
     const token = 'mock_access_token_replace_with_login_response';
@@ -52,8 +53,13 @@ final class AuthSessionNotifier extends Notifier<AuthSessionState> {
   Future<void> registerWithMockCredentials({
     required String email,
     required String password,
+    String? name,
   }) async {
-    await signInWithMockCredentials(email: email, password: password);
+    await signInWithMockCredentials(
+      email: email,
+      password: password,
+      name: name,
+    );
   }
 
   Future<void> signOut() async {
@@ -73,7 +79,15 @@ final class AuthSessionNotifier extends Notifier<AuthSessionState> {
     if (local.isEmpty) return 'Student';
     return '${local[0].toUpperCase()}${local.length > 1 ? local.substring(1) : ''}';
   }
+
+  static String? _displayNameFromInput(String? name) {
+    final value = name?.trim();
+    if (value == null || value.isEmpty) return null;
+    return value;
+  }
 }
 
 final authSessionProvider =
-    NotifierProvider<AuthSessionNotifier, AuthSessionState>(AuthSessionNotifier.new);
+    NotifierProvider<AuthSessionNotifier, AuthSessionState>(
+      AuthSessionNotifier.new,
+    );

--- a/apps/mobile/lib/core/providers/router_provider.dart
+++ b/apps/mobile/lib/core/providers/router_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile/core/providers/auth_session_provider.dart';
 import 'package:mobile/core/routing/app_routes.dart';
+import 'package:mobile/core/testing/mock_catalog.dart';
 import 'package:mobile/features/auth/presentation/login_screen.dart';
 import 'package:mobile/features/auth/presentation/onboarding_screen.dart';
 import 'package:mobile/features/auth/presentation/register_screen.dart';
@@ -83,7 +84,35 @@ final routerProvider = Provider<GoRouter>((ref) {
                     path: ':courseId',
                     builder: (context, state) {
                       final id = state.pathParameters['courseId']!;
-                      return CourseDetailScreen(courseId: id);
+                      final apiCourse = MockCatalog.courseById(id);
+                      final summary = MockCatalog.enrolledSummaries.where((s) => s.courseId == id).firstOrNull;
+
+                      final course = Course(
+                        id: id,
+                        title: apiCourse?.name ?? 'Course',
+                        code: apiCourse?.code ?? 'N/A',
+                        progressPercentage: summary?.progressPercent ?? 0,
+                        modulesCompleted: summary?.modulesDone ?? 0,
+                        totalModules: summary?.modulesTotal ?? 0,
+                        timeSpentHours: 12.0,
+                        averageGrade: 'A-',
+                        badgesCount: 3,
+                        projectsCount: 1,
+                      );
+
+                      const materials = <LectureMaterial>[
+                        LectureMaterial(id: 'm1', title: 'Lecture Notes - Week 1', type: 'pdf', sizeOrDuration: '2.3 MB'),
+                        LectureMaterial(id: 'm2', title: 'Lecture Recording - Intro', type: 'video', sizeOrDuration: '18 min'),
+                        LectureMaterial(id: 'm3', title: 'Lab Sheet 01', type: 'pdf', sizeOrDuration: '1.1 MB'),
+                      ];
+
+                      return CourseDetailsScreen(
+                        course: course,
+                        materials: materials,
+                        onBack: () => context.pop(),
+                        onSummarizeMaterial: (_) {},
+                        onAssistantAsk: () {},
+                      );
                     },
                   ),
                 ],

--- a/apps/mobile/lib/core/widgets/app_header.dart
+++ b/apps/mobile/lib/core/widgets/app_header.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/theme/app_spacing.dart';
+
+class AppHeader extends StatelessWidget {
+  const AppHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    final gradient = LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [scheme.primary, scheme.secondary],
+    );
+
+    Widget gradientText(String text, TextStyle? style) {
+      return ShaderMask(
+        shaderCallback: (bounds) =>
+            gradient.createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
+        blendMode: BlendMode.srcIn,
+        child: Text(text, style: style?.copyWith(color: Colors.white)),
+      );
+    }
+
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.containerPadding,
+          12,
+          AppSpacing.containerPadding,
+          12,
+        ),
+        child: Row(
+          children: [
+            const CircleAvatar(
+              radius: 20,
+              child: Icon(Icons.school, size: 20),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: gradientText(
+                'UniLearn',
+                Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w900,
+                    ),
+              ),
+            ),
+            IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.notifications_none_rounded),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/core/widgets/widgets.dart
+++ b/apps/mobile/lib/core/widgets/widgets.dart
@@ -2,3 +2,4 @@ export 'glass_panel.dart';
 export 'gradient_cta_button.dart';
 export 'labeled_text_field.dart';
 export 'section_header.dart';
+export 'app_header.dart';

--- a/apps/mobile/lib/features/auth/presentation/login_screen.dart
+++ b/apps/mobile/lib/features/auth/presentation/login_screen.dart
@@ -27,7 +27,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   }
 
   Future<void> _submit() async {
-    await ref.read(authSessionProvider.notifier).signInWithMockCredentials(
+    await ref
+        .read(authSessionProvider.notifier)
+        .signInWithMockCredentials(
           email: _email.text.trim(),
           password: _password.text,
         );
@@ -40,144 +42,364 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     final scheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.containerPadding),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const SizedBox(height: 12),
-              Text(
-                'UniLearn',
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.w800,
-                      color: scheme.secondary,
-                    ),
-              ),
-              const SizedBox(height: AppSpacing.sectionGap),
-              GlassPanel(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Text(
-                      'Intellectual access',
-                      style: Theme.of(context).textTheme.headlineMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      'Resume your high-performance academic journey.',
-                      style: Theme.of(context).textTheme.bodyMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: AppSpacing.stackGap),
-                    LabeledTextField(
-                      label: 'Institutional email',
-                      hint: 'student@university.edu',
-                      controller: _email,
-                      keyboardType: TextInputType.emailAddress,
-                      prefixIcon: Icons.mail_outline,
-                    ),
-                    const SizedBox(height: AppSpacing.stackGap),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: LabeledTextField(
-                            label: 'Secure passcode',
-                            hint: '••••••••',
-                            controller: _password,
-                            obscureText: _obscure,
-                            prefixIcon: Icons.lock_outline,
-                            suffixIcon: IconButton(
-                              onPressed: () => setState(() => _obscure = !_obscure),
-                              icon: Icon(
-                                _obscure ? Icons.visibility_outlined : Icons.visibility_off_outlined,
-                                color: scheme.onSurfaceVariant,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: TextButton(
-                        onPressed: () {},
-                        child: Text(
-                          'Forgot password?',
-                          style: TextStyle(color: scheme.secondary, fontWeight: FontWeight.w600),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    GradientCtaButton(label: 'Sign in', onPressed: _submit),
-                    const SizedBox(height: AppSpacing.stackGap),
-                    Row(
-                      children: [
-                        Expanded(child: Divider(color: scheme.outlineVariant.withValues(alpha: 0.5))),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: Text(
-                            'EXTERNAL ACCESS',
-                            style: Theme.of(context).textTheme.labelSmall,
-                          ),
-                        ),
-                        Expanded(child: Divider(color: scheme.outlineVariant.withValues(alpha: 0.5))),
-                      ],
-                    ),
-                    const SizedBox(height: AppSpacing.stackGap),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: OutlinedButton.icon(
-                            onPressed: () {},
-                            icon: const Text('G', style: TextStyle(fontWeight: FontWeight.w800)),
-                            label: const Text('Google'),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: OutlinedButton(
-                            onPressed: () {},
-                            child: const Text('Apple'),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: AppSpacing.stackGap),
-              Text.rich(
-                TextSpan(
-                  text: 'New to UniLearn? ',
-                  style: Theme.of(context).textTheme.bodyMedium,
-                  children: [
-                    TextSpan(
-                      text: 'Create account',
-                      style: TextStyle(color: scheme.secondary, fontWeight: FontWeight.w700),
-                      recognizer: TapGestureRecognizer()
-                        ..onTap = () => context.push(AppRoutes.register),
-                    ),
-                  ],
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: AppSpacing.sectionGap),
-              Wrap(
-                alignment: WrapAlignment.center,
-                spacing: 16,
-                runSpacing: 8,
-                children: [
-                  Text('Privacy', style: Theme.of(context).textTheme.bodySmall),
-                  Text('Terms', style: Theme.of(context).textTheme.bodySmall),
-                  Text('System status', style: Theme.of(context).textTheme.bodySmall),
-                ],
-              ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              scheme.surface,
+              scheme.surface.withValues(alpha: 0.96),
+              scheme.surfaceContainerLowest,
             ],
           ),
         ),
+        child: Stack(
+          children: [
+            Positioned(
+              left: -48,
+              top: 80,
+              child: _GlowOrb(
+                color: scheme.secondary.withValues(alpha: 0.14),
+                size: 180,
+              ),
+            ),
+            Positioned(
+              right: -56,
+              bottom: 120,
+              child: _GlowOrb(
+                color: scheme.primary.withValues(alpha: 0.16),
+                size: 220,
+              ),
+            ),
+            SafeArea(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(AppSpacing.containerPadding),
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
+                      child: IntrinsicHeight(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            const SizedBox(height: 8),
+                            Center(
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 14,
+                                  vertical: 8,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: scheme.surfaceContainerHigh.withValues(
+                                    alpha: 0.75,
+                                  ),
+                                  borderRadius: BorderRadius.circular(999),
+                                  border: Border.all(
+                                    color: scheme.outlineVariant.withValues(
+                                      alpha: 0.35,
+                                    ),
+                                  ),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Container(
+                                      width: 9,
+                                      height: 9,
+                                      decoration: BoxDecoration(
+                                        color: scheme.secondary,
+                                        shape: BoxShape.circle,
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: scheme.secondary.withValues(
+                                              alpha: 0.45,
+                                            ),
+                                            blurRadius: 12,
+                                            spreadRadius: 1,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      'UniLearn secure access',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelMedium
+                                          ?.copyWith(
+                                            letterSpacing: 1.0,
+                                            color: scheme.onSurfaceVariant,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: AppSpacing.stackGap),
+                            Text(
+                              'Welcome back',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.displaySmall
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: -0.6,
+                                  ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Sign in with your university email to continue your learning session and access course resources.',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: scheme.onSurfaceVariant,
+                                    height: 1.45,
+                                  ),
+                            ),
+                            const SizedBox(height: AppSpacing.sectionGap),
+                            GlassPanel(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Container(
+                                        padding: const EdgeInsets.all(10),
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(
+                                            colors: [
+                                              scheme.primary,
+                                              scheme.secondary,
+                                            ],
+                                          ),
+                                          borderRadius: BorderRadius.circular(
+                                            16,
+                                          ),
+                                        ),
+                                        child: const Icon(
+                                          Icons.school_outlined,
+                                          color: Colors.white,
+                                          size: 22,
+                                        ),
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              'Sign in to your workspace',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .titleLarge
+                                                  ?.copyWith(
+                                                    fontWeight: FontWeight.w700,
+                                                  ),
+                                            ),
+                                            const SizedBox(height: 4),
+                                            Text(
+                                              'Enter your university credentials to continue.',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .bodySmall
+                                                  ?.copyWith(
+                                                    color:
+                                                        scheme.onSurfaceVariant,
+                                                  ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: AppSpacing.sectionGap),
+                                  LabeledTextField(
+                                    label: 'University email',
+                                    hint: 'student@university.edu',
+                                    controller: _email,
+                                    keyboardType: TextInputType.emailAddress,
+                                    prefixIcon: Icons.mail_outline,
+                                  ),
+                                  const SizedBox(height: AppSpacing.stackGap),
+                                  LabeledTextField(
+                                    label: 'Password',
+                                    hint: 'Enter your password',
+                                    controller: _password,
+                                    obscureText: _obscure,
+                                    prefixIcon: Icons.lock_outline,
+                                    suffixIcon: IconButton(
+                                      onPressed: () =>
+                                          setState(() => _obscure = !_obscure),
+                                      icon: Icon(
+                                        _obscure
+                                            ? Icons.visibility_outlined
+                                            : Icons.visibility_off_outlined,
+                                        color: scheme.onSurfaceVariant,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(height: 6),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: Text(
+                                          'Keep your account secure on shared devices.',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall
+                                              ?.copyWith(
+                                                color: scheme.onSurfaceVariant,
+                                              ),
+                                        ),
+                                      ),
+                                      TextButton(
+                                        onPressed: () {},
+                                        child: Text(
+                                          'Forgot password?',
+                                          style: TextStyle(
+                                            color: scheme.secondary,
+                                            fontWeight: FontWeight.w700,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 8),
+                                  GradientCtaButton(
+                                    label: 'Sign in',
+                                    onPressed: _submit,
+                                    icon: Icons.arrow_forward_rounded,
+                                  ),
+                                  const SizedBox(height: AppSpacing.sectionGap),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: Divider(
+                                          color: scheme.outlineVariant
+                                              .withValues(alpha: 0.5),
+                                        ),
+                                      ),
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 12,
+                                        ),
+                                        child: Text(
+                                          'OR CONTINUE WITH',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .labelSmall
+                                              ?.copyWith(letterSpacing: 1.1),
+                                        ),
+                                      ),
+                                      Expanded(
+                                        child: Divider(
+                                          color: scheme.outlineVariant
+                                              .withValues(alpha: 0.5),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: AppSpacing.stackGap),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: OutlinedButton.icon(
+                                          onPressed: () {},
+                                          icon: const Text(
+                                            'G',
+                                            style: TextStyle(
+                                              fontWeight: FontWeight.w800,
+                                            ),
+                                          ),
+                                          label: const Text('Google'),
+                                        ),
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: OutlinedButton.icon(
+                                          onPressed: () {},
+                                          icon: const Icon(Icons.apple),
+                                          label: const Text('Apple'),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: AppSpacing.stackGap),
+                            Text.rich(
+                              TextSpan(
+                                text: 'New to UniLearn? ',
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(color: scheme.onSurfaceVariant),
+                                children: [
+                                  TextSpan(
+                                    text: 'Create account',
+                                    style: TextStyle(
+                                      color: scheme.secondary,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                    recognizer: TapGestureRecognizer()
+                                      ..onTap = () =>
+                                          context.push(AppRoutes.register),
+                                  ),
+                                ],
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: AppSpacing.sectionGap),
+                            Wrap(
+                              alignment: WrapAlignment.center,
+                              spacing: 16,
+                              runSpacing: 8,
+                              children: [
+                                Text(
+                                  'Privacy',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                Text(
+                                  'Terms',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                Text(
+                                  'System status',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GlowOrb extends StatelessWidget {
+  const _GlowOrb({required this.color, required this.size});
+
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: RadialGradient(colors: [color, color.withValues(alpha: 0.0)]),
       ),
     );
   }

--- a/apps/mobile/lib/features/auth/presentation/onboarding_screen.dart
+++ b/apps/mobile/lib/features/auth/presentation/onboarding_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,21 +21,28 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   final PageController _pageController = PageController();
   int _index = 0;
 
+  static const _imageUrl =
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuCd2f_sjcHXIxK5-vjcV3crxZZbYQ-9MnavBsJxNzkQYdRBGpFxWy48q7sNstg3LhSMcTLXJ6OBnlYUBgHp4hd-xmLltdFA1LroFrnzKjgJ4HSWXoTbuQGGI0aLV83CQr6XZoBMZSyMQaxd_TtWcw-nExp1qlNvVeYxfUQs6Qz7e1zIxlrMDBgmwJTjW1xX52wnbQlE4hCcj9S_gCojITarFWDV8rGb5IcVJlGiDadlimqw4wcngxovFxEN5Xgseq0H0bchB9xVgXjj';
+
   static const _pages = [
     _OnboardPageData(
       title: 'Your AI study partner',
       highlightWord: 'partner',
-      body: 'Summarize lectures, generate quizzes, and track progress instantly.',
+      body:
+          'Summarize lectures, generate quizzes, and track progress instantly.',
+      imageUrl: _imageUrl,
     ),
     _OnboardPageData(
       title: 'Stay exam-ready',
       highlightWord: 'exam-ready',
       body: 'Deadlines, streaks, and smart nudges keep you in rhythm.',
+      imageUrl: _imageUrl,
     ),
     _OnboardPageData(
       title: 'Built for focus',
       highlightWord: 'focus',
       body: 'A calm, cinematic workspace designed for deep work.',
+      imageUrl: _imageUrl,
     ),
   ];
 
@@ -55,99 +64,147 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     final extras = context.uniLearnExtras;
 
     return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        title: Text('UniLearn', style: Theme.of(context).textTheme.titleMedium),
-        actions: [
-          TextButton(
-            onPressed: () async {
-              await _finishOnboardingAndGoLogin();
-            },
-            child: Text('Skip', style: TextStyle(color: scheme.secondary)),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              scheme.surface,
+              scheme.surface.withValues(alpha: 0.96),
+              scheme.surfaceContainerLowest,
+            ],
           ),
-        ],
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.containerPadding),
-          child: Column(
-            children: [
-              Expanded(
-                child: PageView.builder(
-                  controller: _pageController,
-                  itemCount: _pages.length,
-                  onPageChanged: (i) => setState(() => _index = i),
-                  itemBuilder: (context, i) {
-                    final p = _pages[i];
-                    return _OnboardPage(
-                      data: p,
-                      gradient: extras.primaryGradient,
-                    );
-                  },
-                ),
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: List.generate(_pages.length, (i) {
-                  final active = i == _index;
-                  return AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
-                    margin: const EdgeInsets.symmetric(horizontal: 4),
-                    height: 6,
-                    width: active ? 28 : 6,
-                    decoration: BoxDecoration(
-                      color: active ? scheme.secondary : scheme.outlineVariant,
-                      borderRadius: BorderRadius.circular(999),
-                      boxShadow: active
-                          ? [
-                              BoxShadow(
-                                color: scheme.secondary.withValues(alpha: 0.45),
-                                blurRadius: 10,
-                              ),
-                            ]
-                          : null,
-                    ),
-                  );
-                }),
-              ),
-              const SizedBox(height: AppSpacing.stackGap),
-              SizedBox(
-                width: double.infinity,
-                child: GradientCtaButton(
-                  label: _index == _pages.length - 1 ? 'Get started' : 'Next',
-                  icon: Icons.arrow_forward,
-                  onPressed: () async {
-                    if (_index < _pages.length - 1) {
-                      await _pageController.nextPage(
-                        duration: const Duration(milliseconds: 300),
-                        curve: Curves.easeOutCubic,
-                      );
-                    } else {
-                      await _finishOnboardingAndGoLogin();
-                    }
-                  },
-                ),
-              ),
-              const SizedBox(height: AppSpacing.stackGap),
-              Text.rich(
-                TextSpan(
-                  text: 'Already have an account? ',
-                  style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        child: Stack(
+          children: [
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.containerPadding),
+                child: Column(
                   children: [
-                    TextSpan(
-                      text: 'Log in',
-                      style: TextStyle(
-                        color: scheme.secondary,
-                        fontWeight: FontWeight.w700,
+                    Expanded(
+                      child: PageView.builder(
+                        controller: _pageController,
+                        itemCount: _pages.length,
+                        onPageChanged: (i) => setState(() => _index = i),
+                        itemBuilder: (context, i) {
+                          final p = _pages[i];
+                          return _OnboardPage(
+                            data: p,
+                            gradient: extras.primaryGradient,
+                          );
+                        },
                       ),
-                      recognizer: TapGestureRecognizer()..onTap = _finishOnboardingAndGoLogin,
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: List.generate(_pages.length, (i) {
+                        final active = i == _index;
+                        return AnimatedContainer(
+                          duration: const Duration(milliseconds: 200),
+                          margin: const EdgeInsets.symmetric(horizontal: 4),
+                          height: 6,
+                          width: active ? 28 : 6,
+                          decoration: BoxDecoration(
+                            color: active
+                                ? scheme.secondary
+                                : scheme.outlineVariant,
+                            borderRadius: BorderRadius.circular(999),
+                            boxShadow: active
+                                ? [
+                                    BoxShadow(
+                                      color: scheme.secondary.withValues(
+                                        alpha: 0.45,
+                                      ),
+                                      blurRadius: 10,
+                                    ),
+                                  ]
+                                : null,
+                          ),
+                        );
+                      }),
+                    ),
+                    const SizedBox(height: AppSpacing.stackGap),
+                    SizedBox(
+                      width: double.infinity,
+                      child: GradientCtaButton(
+                        label: _index == _pages.length - 1
+                            ? 'Get started'
+                            : 'Next',
+                        icon: Icons.arrow_forward,
+                        onPressed: () async {
+                          if (_index < _pages.length - 1) {
+                            await _pageController.nextPage(
+                              duration: const Duration(milliseconds: 300),
+                              curve: Curves.easeOutCubic,
+                            );
+                          } else {
+                            await _finishOnboardingAndGoLogin();
+                          }
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.stackGap),
+                    Text.rich(
+                      TextSpan(
+                        text: 'Already have an account? ',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                        children: [
+                          TextSpan(
+                            text: 'Log in',
+                            style: TextStyle(
+                              color: scheme.secondary,
+                              fontWeight: FontWeight.w700,
+                            ),
+                            recognizer: TapGestureRecognizer()
+                              ..onTap = _finishOnboardingAndGoLogin,
+                          ),
+                        ],
+                      ),
+                      textAlign: TextAlign.center,
                     ),
                   ],
                 ),
-                textAlign: TextAlign.center,
               ),
-            ],
-          ),
+            ),
+            Positioned(
+              top: 16,
+              right: 16,
+              child: SafeArea(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: scheme.surfaceContainerHigh.withValues(alpha: 0.85),
+                    borderRadius: BorderRadius.circular(999),
+                    border: Border.all(
+                      color: scheme.outlineVariant.withValues(alpha: 0.35),
+                    ),
+                  ),
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: InkWell(
+                      onTap: _finishOnboardingAndGoLogin,
+                      borderRadius: BorderRadius.circular(999),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 10,
+                        ),
+                        child: Text(
+                          'Skip',
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                color: scheme.secondary,
+                                fontWeight: FontWeight.w700,
+                              ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -159,18 +216,17 @@ class _OnboardPageData {
     required this.title,
     required this.highlightWord,
     required this.body,
+    required this.imageUrl,
   });
 
   final String title;
   final String highlightWord;
   final String body;
+  final String imageUrl;
 }
 
 class _OnboardPage extends StatelessWidget {
-  const _OnboardPage({
-    required this.data,
-    required this.gradient,
-  });
+  const _OnboardPage({required this.data, required this.gradient});
 
   final _OnboardPageData data;
   final LinearGradient gradient;
@@ -199,9 +255,9 @@ class _OnboardPage extends StatelessWidget {
                 shaderCallback: (b) => gradient.createShader(b),
                 child: Text(
                   mid,
-                  style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-                        color: Colors.white,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.headlineLarge?.copyWith(color: Colors.white),
                 ),
               ),
             ),
@@ -218,33 +274,104 @@ class _OnboardPage extends StatelessWidget {
       );
     }
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Container(
-          height: 220,
-          width: 220,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(24),
-            gradient: LinearGradient(
-              colors: [
-                scheme.surfaceContainerHigh,
-                scheme.surfaceContainer,
-              ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final imageHeight = constraints.maxHeight.isFinite
+            ? constraints.maxHeight * 0.62
+            : 360.0;
+
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              height: imageHeight,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(34),
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      scheme.primary.withValues(alpha: 0.14),
+                      scheme.secondary.withValues(alpha: 0.10),
+                      scheme.surfaceContainerHighest.withValues(alpha: 0.96),
+                    ],
+                  ),
+                  border: Border.all(
+                    color: scheme.outlineVariant.withValues(alpha: 0.32),
+                    width: 1.2,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: scheme.shadow.withValues(alpha: 0.18),
+                      blurRadius: 30,
+                      offset: const Offset(0, 16),
+                    ),
+                  ],
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(34),
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Image.network(
+                        data.imageUrl,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) {
+                          return Container(
+                            color: scheme.surfaceContainer,
+                            child: Icon(
+                              Icons.image_not_supported_outlined,
+                              size: 64,
+                              color: scheme.onSurfaceVariant,
+                            ),
+                          );
+                        },
+                      ),
+                      DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              scheme.surface.withValues(alpha: 0.10),
+                              scheme.primary.withValues(alpha: 0.12),
+                              scheme.surface.withValues(alpha: 0.26),
+                            ],
+                          ),
+                        ),
+                      ),
+                      DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: RadialGradient(
+                            center: Alignment.topRight,
+                            radius: 1.1,
+                            colors: [
+                              scheme.secondary.withValues(alpha: 0.18),
+                              Colors.transparent,
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             ),
-            border: Border.all(color: scheme.outlineVariant.withValues(alpha: 0.4)),
-          ),
-          child: Icon(Icons.auto_awesome, size: 72, color: scheme.primary.withValues(alpha: 0.9)),
-        ),
-        const SizedBox(height: AppSpacing.sectionGap),
-        titleWidget,
-        const SizedBox(height: AppSpacing.stackGap),
-        Text(
-          data.body,
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: scheme.onSurfaceVariant),
-          textAlign: TextAlign.center,
-        ),
-      ],
+            const SizedBox(height: AppSpacing.sectionGap),
+            titleWidget,
+            const SizedBox(height: AppSpacing.stackGap),
+            Text(
+              data.body,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(color: scheme.onSurfaceVariant),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/apps/mobile/lib/features/auth/presentation/register_screen.dart
+++ b/apps/mobile/lib/features/auth/presentation/register_screen.dart
@@ -15,18 +15,23 @@ class RegisterScreen extends ConsumerStatefulWidget {
 }
 
 class _RegisterScreenState extends ConsumerState<RegisterScreen> {
+  final _fullName = TextEditingController();
   final _email = TextEditingController();
   final _password = TextEditingController();
 
   @override
   void dispose() {
+    _fullName.dispose();
     _email.dispose();
     _password.dispose();
     super.dispose();
   }
 
   Future<void> _submit() async {
-    await ref.read(authSessionProvider.notifier).registerWithMockCredentials(
+    await ref
+        .read(authSessionProvider.notifier)
+        .registerWithMockCredentials(
+          name: _fullName.text.trim(),
           email: _email.text.trim(),
           password: _password.text,
         );
@@ -39,61 +44,343 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
     final scheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Create account')),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.containerPadding),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                'Join UniLearn',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              const SizedBox(height: AppSpacing.stackGap),
-              GlassPanel(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    LabeledTextField(
-                      label: 'Email',
-                      hint: 'you@university.edu',
-                      controller: _email,
-                      keyboardType: TextInputType.emailAddress,
-                      prefixIcon: Icons.mail_outline,
-                    ),
-                    const SizedBox(height: AppSpacing.stackGap),
-                    LabeledTextField(
-                      label: 'Password',
-                      hint: '••••••••',
-                      controller: _password,
-                      obscureText: true,
-                      prefixIcon: Icons.lock_outline,
-                    ),
-                    const SizedBox(height: AppSpacing.stackGap),
-                    GradientCtaButton(label: 'Create account', onPressed: _submit),
-                  ],
-                ),
-              ),
-              const SizedBox(height: AppSpacing.stackGap),
-              Text.rich(
-                TextSpan(
-                  text: 'Already registered? ',
-                  style: Theme.of(context).textTheme.bodyMedium,
-                  children: [
-                    TextSpan(
-                      text: 'Sign in',
-                      style: TextStyle(color: scheme.secondary, fontWeight: FontWeight.w700),
-                      recognizer: TapGestureRecognizer()
-                        ..onTap = () => context.go(AppRoutes.login),
-                    ),
-                  ],
-                ),
-                textAlign: TextAlign.center,
-              ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              scheme.surface,
+              scheme.surface.withValues(alpha: 0.96),
+              scheme.surfaceContainerLowest,
             ],
           ),
         ),
+        child: Stack(
+          children: [
+            Positioned(
+              left: -48,
+              top: 80,
+              child: _GlowOrb(
+                color: scheme.secondary.withValues(alpha: 0.14),
+                size: 180,
+              ),
+            ),
+            Positioned(
+              right: -56,
+              bottom: 120,
+              child: _GlowOrb(
+                color: scheme.primary.withValues(alpha: 0.16),
+                size: 220,
+              ),
+            ),
+            SafeArea(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(AppSpacing.containerPadding),
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
+                      child: IntrinsicHeight(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            const SizedBox(height: 8),
+                            Center(
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 14,
+                                  vertical: 8,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: scheme.surfaceContainerHigh.withValues(
+                                    alpha: 0.75,
+                                  ),
+                                  borderRadius: BorderRadius.circular(999),
+                                  border: Border.all(
+                                    color: scheme.outlineVariant.withValues(
+                                      alpha: 0.35,
+                                    ),
+                                  ),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Container(
+                                      width: 9,
+                                      height: 9,
+                                      decoration: BoxDecoration(
+                                        color: scheme.primary,
+                                        shape: BoxShape.circle,
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: scheme.primary.withValues(
+                                              alpha: 0.45,
+                                            ),
+                                            blurRadius: 12,
+                                            spreadRadius: 1,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      'UniLearn account setup',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelMedium
+                                          ?.copyWith(
+                                            letterSpacing: 1.0,
+                                            color: scheme.onSurfaceVariant,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: AppSpacing.stackGap),
+                            Text(
+                              'Create your account',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.displaySmall
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: -0.6,
+                                  ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Join UniLearn with your university email to unlock course resources, notes, and study tools.',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: scheme.onSurfaceVariant,
+                                    height: 1.45,
+                                  ),
+                            ),
+                            const SizedBox(height: AppSpacing.sectionGap),
+                            GlassPanel(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Container(
+                                        padding: const EdgeInsets.all(10),
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(
+                                            colors: [
+                                              scheme.primary,
+                                              scheme.secondary,
+                                            ],
+                                          ),
+                                          borderRadius: BorderRadius.circular(
+                                            16,
+                                          ),
+                                        ),
+                                        child: const Icon(
+                                          Icons.person_add_alt_1_outlined,
+                                          color: Colors.white,
+                                          size: 22,
+                                        ),
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              'Start your UniLearn journey',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .titleLarge
+                                                  ?.copyWith(
+                                                    fontWeight: FontWeight.w700,
+                                                  ),
+                                            ),
+                                            const SizedBox(height: 4),
+                                            Text(
+                                              'Use your institution email to create a secure student account.',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .bodySmall
+                                                  ?.copyWith(
+                                                    color:
+                                                        scheme.onSurfaceVariant,
+                                                  ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: AppSpacing.sectionGap),
+                                  LabeledTextField(
+                                    label: 'Full name',
+                                    hint: 'John Doe',
+                                    controller: _fullName,
+                                    prefixIcon: Icons.person_outline,
+                                  ),
+                                  const SizedBox(height: AppSpacing.stackGap),
+                                  LabeledTextField(
+                                    label: 'University email',
+                                    hint: 'you@university.edu',
+                                    controller: _email,
+                                    keyboardType: TextInputType.emailAddress,
+                                    prefixIcon: Icons.mail_outline,
+                                  ),
+                                  const SizedBox(height: AppSpacing.stackGap),
+                                  LabeledTextField(
+                                    label: 'Password',
+                                    hint: '••••••••',
+                                    controller: _password,
+                                    obscureText: true,
+                                    prefixIcon: Icons.lock_outline,
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    'Use at least 6 characters for a stronger account password.',
+                                    style: Theme.of(context).textTheme.bodySmall
+                                        ?.copyWith(
+                                          color: scheme.onSurfaceVariant,
+                                        ),
+                                  ),
+                                  const SizedBox(height: AppSpacing.stackGap),
+                                  GradientCtaButton(
+                                    label: 'Create account',
+                                    onPressed: _submit,
+                                    icon: Icons.arrow_forward_rounded,
+                                  ),
+                                  const SizedBox(height: AppSpacing.sectionGap),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: Divider(
+                                          color: scheme.outlineVariant
+                                              .withValues(alpha: 0.5),
+                                        ),
+                                      ),
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 12,
+                                        ),
+                                        child: Text(
+                                          'OR CONTINUE WITH',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .labelSmall
+                                              ?.copyWith(letterSpacing: 1.1),
+                                        ),
+                                      ),
+                                      Expanded(
+                                        child: Divider(
+                                          color: scheme.outlineVariant
+                                              .withValues(alpha: 0.5),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: AppSpacing.stackGap),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: OutlinedButton.icon(
+                                          onPressed: () {},
+                                          icon: const Text(
+                                            'G',
+                                            style: TextStyle(
+                                              fontWeight: FontWeight.w800,
+                                            ),
+                                          ),
+                                          label: const Text('Google'),
+                                        ),
+                                      ),
+                                      const SizedBox(width: 12),
+                                      Expanded(
+                                        child: OutlinedButton.icon(
+                                          onPressed: () {},
+                                          icon: const Icon(Icons.apple),
+                                          label: const Text('Apple'),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: AppSpacing.stackGap),
+                            Text.rich(
+                              TextSpan(
+                                text: 'Already registered? ',
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(color: scheme.onSurfaceVariant),
+                                children: [
+                                  TextSpan(
+                                    text: 'Sign in',
+                                    style: TextStyle(
+                                      color: scheme.secondary,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                    recognizer: TapGestureRecognizer()
+                                      ..onTap = () =>
+                                          context.go(AppRoutes.login),
+                                  ),
+                                ],
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: AppSpacing.sectionGap),
+                            Wrap(
+                              alignment: WrapAlignment.center,
+                              spacing: 16,
+                              runSpacing: 8,
+                              children: [
+                                Text(
+                                  'Privacy',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                Text(
+                                  'Terms',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                Text(
+                                  'System status',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GlowOrb extends StatelessWidget {
+  const _GlowOrb({required this.color, required this.size});
+
+  final Color color;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: RadialGradient(colors: [color, color.withValues(alpha: 0.0)]),
       ),
     );
   }

--- a/apps/mobile/lib/features/auth/presentation/splash_screen.dart
+++ b/apps/mobile/lib/features/auth/presentation/splash_screen.dart
@@ -14,6 +14,12 @@ class SplashScreen extends ConsumerStatefulWidget {
 }
 
 class _SplashScreenState extends ConsumerState<SplashScreen> {
+  static const _minSplashDuration = Duration(milliseconds: 1800);
+  static const _backgroundImageUrl =
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuB8eEmwxGtwcZGuL78pXL9F0XDxuX3q6KfZUCJdg2R2Z4DGNAfqI5P0o3JMNlGcjljZX0xrScWv5bE_7oSNOfmsnqzY6kQSF71qfYoSJUT-MfRlBxz9b-K1-IV8CSZLu1eCgE2h4mnFS7-HppKZ_NvF6UAjj4Gcop51PKeZI1aY-scIILL8smc6-Ywq8H1hcYh2twu2x6Tv3RPGTYDSd0PVGuX4exp7hPoc6C5wAE9aPYqHSwvBdBWIVXsYNWq3-pm0Zup2Oo577RJm';
+
+  late final DateTime _openedAt = DateTime.now();
+
   @override
   void initState() {
     super.initState();
@@ -23,6 +29,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   Future<void> _bootstrap() async {
     final notifier = ref.read(authSessionProvider.notifier);
     await notifier.tryRestore();
+
+    final elapsed = DateTime.now().difference(_openedAt);
+    final remaining = _minSplashDuration - elapsed;
+    if (remaining > Duration.zero) {
+      await Future<void>.delayed(remaining);
+    }
 
     if (!mounted) return;
 
@@ -48,54 +60,129 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
 
     return Scaffold(
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.containerPadding),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ShaderMask(
-                shaderCallback: (bounds) => extras.primaryGradient.createShader(bounds),
-                child: Text(
-                  'UniLearn',
-                  style: Theme.of(context).textTheme.displaySmall?.copyWith(
-                        color: Colors.white,
-                        fontWeight: FontWeight.w800,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Image.network(
+              _backgroundImageUrl,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) {
+                return Container(color: scheme.surface);
+              },
+            ),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    scheme.surface.withValues(alpha: 0.30),
+                    scheme.surface.withValues(alpha: 0.58),
+                    scheme.surface.withValues(alpha: 0.86),
+                  ],
+                ),
+              ),
+            ),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: RadialGradient(
+                  center: Alignment.topCenter,
+                  radius: 1.15,
+                  colors: [
+                    extras.primaryGradient.colors.first.withValues(alpha: 0.20),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.containerPadding),
+              child: Column(
+                children: [
+                  const Spacer(flex: 2),
+                  Container(
+                    padding: const EdgeInsets.all(20),
+                    decoration: BoxDecoration(
+                      color: scheme.surfaceContainerHigh.withValues(
+                        alpha: 0.52,
                       ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Academy',
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      color: scheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w600,
+                      borderRadius: BorderRadius.circular(28),
+                      border: Border.all(
+                        color: scheme.outlineVariant.withValues(alpha: 0.28),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: scheme.shadow.withValues(alpha: 0.18),
+                          blurRadius: 28,
+                          offset: const Offset(0, 14),
+                        ),
+                      ],
                     ),
-              ),
-              const SizedBox(height: AppSpacing.sectionGap),
-              Text(
-                'Learn smarter with AI',
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-              const SizedBox(height: AppSpacing.stackGap),
-              Text(
-                'Initializing academic core',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: AppSpacing.sectionGap),
-              SizedBox(
-                width: 200,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(4),
-                  child: LinearProgressIndicator(
-                    minHeight: 4,
-                    backgroundColor: scheme.surfaceContainerHigh,
-                    valueColor: AlwaysStoppedAnimation<Color>(scheme.primary),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ShaderMask(
+                          shaderCallback: (bounds) =>
+                              extras.primaryGradient.createShader(bounds),
+                          child: Text(
+                            'UniLearn',
+                            style: Theme.of(context).textTheme.displaySmall
+                                ?.copyWith(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w900,
+                                ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          'Academy',
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(
+                                color: scheme.onSurfaceVariant,
+                                fontWeight: FontWeight.w700,
+                                letterSpacing: 0.5,
+                              ),
+                        ),
+                        const SizedBox(height: AppSpacing.stackGap),
+                        Text(
+                          'Learn smarter with AI',
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                color: scheme.onSurface.withValues(alpha: 0.88),
+                              ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
+                  const SizedBox(height: AppSpacing.sectionGap),
+                  Text(
+                    'Initializing academic core',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.sectionGap),
+                  SizedBox(
+                    width: 220,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(999),
+                      child: LinearProgressIndicator(
+                        minHeight: 5,
+                        backgroundColor: scheme.surfaceContainerHigh.withValues(
+                          alpha: 0.8,
+                        ),
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          scheme.secondary,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const Spacer(flex: 3),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/features/courses/presentation/course_detail_screen.dart
+++ b/apps/mobile/lib/features/courses/presentation/course_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:mobile/theme/app_radii.dart';
 import 'package:mobile/theme/app_spacing.dart';
@@ -32,15 +34,18 @@ class Course {
 class LectureMaterial {
   final String id;
   final String title;
-  final String type; // 'pdf' | 'video' | 'lab'
-  final String sizeOrDuration;
+  final String size;
+  final String time;
 
   const LectureMaterial({
     required this.id,
     required this.title,
-    required this.type,
-    required this.sizeOrDuration,
-  });
+    String? size,
+    String? time,
+    String? type,
+    String? sizeOrDuration,
+  }) : size = size ?? sizeOrDuration ?? 'N/A',
+       time = time ?? sizeOrDuration ?? (type == 'video' ? '00:00' : 'N/A');
 }
 
 class CourseDetailsScreen extends StatefulWidget {
@@ -63,27 +68,45 @@ class CourseDetailsScreen extends StatefulWidget {
   State<CourseDetailsScreen> createState() => _CourseDetailsScreenState();
 }
 
-class _CourseDetailsScreenState extends State<CourseDetailsScreen>
-    with SingleTickerProviderStateMixin {
-  late TabController _tabController;
+class _CourseDetailsScreenState extends State<CourseDetailsScreen> {
   static const _bottomBackgroundImageUrl =
       'https://lh3.googleusercontent.com/aida-public/AB6AXuB8eEmwxGtwcZGuL78pXL9F0XDxuX3q6KfZUCJdg2R2Z4DGNAfqI5P0o3JMNlGcjljZX0xrScWv5bE_7oSNOfmsnqzY6kQSF71qfYoSJUT-MfRlBxz9b-K1-IV8CSZLu1eCgE2h4mnFS7-HppKZ_NvF6UAjj4Gcop51PKeZI1aY-scIILL8smc6-Ywq8H1hcYh2twu2x6Tv3RPGTYDSd0PVGuX4exp7hPoc6C5wAE9aPYqHSwvBdBWIVXsYNWq3-pm0Zup2Oo577RJm';
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
   }
 
   @override
   void dispose() {
-    _tabController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
+
+    // sample/trash materials for now (ignore fetched materials)
+    final materials = <LectureMaterial>[
+      const LectureMaterial(
+        id: 'm1',
+        title: 'Lecture 1 — Introduction to CNNs',
+        size: '12.8 MB',
+        time: '18:24',
+      ),
+      const LectureMaterial(
+        id: 'm2',
+        title: 'Week 1 Slides',
+        size: '2.3 MB',
+        time: '06:12',
+      ),
+      const LectureMaterial(
+        id: 'm3',
+        title: 'Lab 1 — Build a small CNN',
+        size: '8.1 MB',
+        time: '24:40',
+      ),
+    ];
 
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
@@ -99,12 +122,6 @@ class _CourseDetailsScreenState extends State<CourseDetailsScreen>
           style: Theme.of(context).textTheme.titleSmall,
         ),
         centerTitle: false,
-        actions: [
-          IconButton(
-            icon: Icon(Icons.notifications, color: scheme.primary, size: 20),
-            onPressed: () {},
-          ),
-        ],
       ),
       body: Stack(
         fit: StackFit.expand,
@@ -118,13 +135,19 @@ class _CourseDetailsScreenState extends State<CourseDetailsScreen>
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
-                    Image.network(
-                      _bottomBackgroundImageUrl,
-                      fit: BoxFit.cover,
-                      alignment: Alignment.bottomCenter,
-                      errorBuilder: (context, error, stackTrace) {
-                        return const SizedBox.shrink();
-                      },
+                    ClipRect(
+                      child: ImageFiltered(
+                        imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                        child: Image.network(
+                          _bottomBackgroundImageUrl,
+                          fit: BoxFit.cover,
+                          alignment: Alignment.bottomCenter,
+                          filterQuality: FilterQuality.low,
+                          errorBuilder: (context, error, stackTrace) {
+                            return const SizedBox.shrink();
+                          },
+                        ),
+                      ),
                     ),
                     DecoratedBox(
                       decoration: BoxDecoration(
@@ -150,413 +173,447 @@ class _CourseDetailsScreenState extends State<CourseDetailsScreen>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-              // Hero Progress banner
-              Container(
-                constraints: const BoxConstraints(minHeight: 252),
-                padding: const EdgeInsets.all(AppSpacing.stackGap),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      scheme.surfaceContainerHighest.withOpacity(0.92),
-                      scheme.surfaceContainerHigh.withOpacity(0.72),
-                    ],
-                  ),
-                  borderRadius: BorderRadius.circular(AppRadii.xl),
-                  border: Border.all(color: scheme.primary.withOpacity(0.10)),
-                  boxShadow: [
-                    BoxShadow(
-                      color: scheme.shadow.withOpacity(0.08),
-                      blurRadius: 24,
-                      offset: const Offset(0, 10),
+                  // Hero Progress banner
+                  Container(
+                    constraints: const BoxConstraints(minHeight: 252),
+                    padding: const EdgeInsets.all(AppSpacing.stackGap),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          scheme.surfaceContainerHighest.withOpacity(0.92),
+                          scheme.surfaceContainerHigh.withOpacity(0.72),
+                        ],
+                      ),
+                      borderRadius: BorderRadius.circular(AppRadii.xl),
+                      border: Border.all(
+                        color: scheme.primary.withOpacity(0.10),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: scheme.shadow.withOpacity(0.08),
+                          blurRadius: 24,
+                          offset: const Offset(0, 10),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Stack(
-                      alignment: Alignment.center,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Container(
-                          width: 108,
-                          height: 108,
-                          decoration: BoxDecoration(
-                            color: scheme.primary.withOpacity(0.08),
-                            shape: BoxShape.circle,
-                          ),
-                        ),
-                        SizedBox(
-                          width: 96,
-                          height: 96,
-                          child: CircularProgressIndicator(
-                            value: widget.course.progressPercentage / 100.0,
-                            strokeWidth: 6.5,
-                            strokeCap: StrokeCap.round,
-                            backgroundColor: scheme.surface.withOpacity(0.22),
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              scheme.primary,
+                        Stack(
+                          alignment: Alignment.center,
+                          children: [
+                            Container(
+                              width: 108,
+                              height: 108,
+                              decoration: BoxDecoration(
+                                color: scheme.primary.withOpacity(0.08),
+                                shape: BoxShape.circle,
+                              ),
                             ),
+                            SizedBox(
+                              width: 96,
+                              height: 96,
+                              child: CircularProgressIndicator(
+                                value: widget.course.progressPercentage / 100.0,
+                                strokeWidth: 6.5,
+                                strokeCap: StrokeCap.round,
+                                backgroundColor: scheme.surface.withOpacity(
+                                  0.22,
+                                ),
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  scheme.primary,
+                                ),
+                              ),
+                            ),
+                            Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  '${widget.course.progressPercentage}%',
+                                  style: Theme.of(context).textTheme.titleMedium
+                                      ?.copyWith(
+                                        color: scheme.primary,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                ),
+                                Text(
+                                  'COMPLETE',
+                                  style: Theme.of(context).textTheme.labelSmall
+                                      ?.copyWith(
+                                        color: scheme.onSurfaceVariant,
+                                        fontSize: 10,
+                                      ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                        const SizedBox(width: 22),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 5,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: scheme.primary.withOpacity(0.12),
+                                  borderRadius: BorderRadius.circular(
+                                    AppRadii.full,
+                                  ),
+                                  border: Border.all(
+                                    color: scheme.primary.withOpacity(0.18),
+                                  ),
+                                ),
+                                child: Text(
+                                  'MODULE ${widget.course.modulesCompleted.toString().padLeft(2, '0')}',
+                                  style: Theme.of(context).textTheme.labelSmall
+                                      ?.copyWith(
+                                        color: scheme.primary,
+                                        fontWeight: FontWeight.w700,
+                                        fontSize: 10,
+                                      ),
+                                ),
+                              ),
+                              const SizedBox(height: 9),
+                              Text(
+                                widget.course.title,
+                                style: Theme.of(context).textTheme.titleLarge
+                                    ?.copyWith(
+                                      color: scheme.onSurface,
+                                      fontWeight: FontWeight.w800,
+                                    ),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                'Advanced Neural Networks and Deep Learning architectures for real-world predictive modeling.',
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(color: scheme.onSurfaceVariant),
+                              ),
+                              const SizedBox(height: 18),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: _buildHeroActionButton(
+                                      context,
+                                      icon: Icons.play_arrow_rounded,
+                                      label: 'Continue learning',
+                                      isPrimary: true,
+                                      onPressed: () {},
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: _buildHeroActionButton(
+                                      context,
+                                      icon: Icons.menu_book_outlined,
+                                      label: 'Syllabus',
+                                      isPrimary: false,
+                                      onPressed: () {},
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
                           ),
                         ),
-                        Column(
-                          mainAxisSize: MainAxisSize.min,
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  // Activity metrics
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.stackGap),
+                    decoration: _cardDecoration(scheme),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'COURSE ACTIVITY',
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: scheme.onSurfaceVariant,
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                        const SizedBox(height: 12),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
                             Text(
-                              '${widget.course.progressPercentage}%',
-                              style: Theme.of(context).textTheme.titleMedium
+                              'Time Spent',
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: scheme.onSurfaceVariant),
+                            ),
+                            Text(
+                              '${widget.course.timeSpentHours}h',
+                              style: Theme.of(context).textTheme.bodyMedium
                                   ?.copyWith(
                                     color: scheme.primary,
                                     fontWeight: FontWeight.bold,
                                   ),
                             ),
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(AppRadii.full),
+                          child: LinearProgressIndicator(
+                            value: widget.course.progressPercentage / 100.0,
+                            minHeight: 8,
+                            backgroundColor: scheme.surface.withOpacity(0.20),
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              scheme.primary,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 14),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
                             Text(
-                              'COMPLETE',
-                              style: Theme.of(context).textTheme.labelSmall
+                              'Average Grade',
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: scheme.onSurfaceVariant),
+                            ),
+                            Text(
+                              widget.course.averageGrade,
+                              style: Theme.of(context).textTheme.bodyMedium
                                   ?.copyWith(
-                                    color: scheme.onSurfaceVariant,
-                                    fontSize: 10,
+                                    color: scheme.secondary,
+                                    fontWeight: FontWeight.bold,
                                   ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 14),
+                        Divider(color: scheme.onSurface.withOpacity(0.08)),
+                        const SizedBox(height: 14),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          children: [
+                            _buildMetricCol(
+                              widget.course.badgesCount.toString(),
+                              'Badges',
+                            ),
+                            _buildMetricCol(
+                              widget.course.modulesCompleted.toString().padLeft(
+                                2,
+                                '0',
+                              ),
+                              'Completed',
+                            ),
+                            _buildMetricCol(
+                              widget.course.projectsCount.toString(),
+                              'Projects',
                             ),
                           ],
                         ),
                       ],
                     ),
-                    const SizedBox(width: 22),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 12,
-                              vertical: 5,
-                            ),
-                            decoration: BoxDecoration(
-                              color: scheme.primary.withOpacity(0.12),
-                              borderRadius: BorderRadius.circular(
-                                AppRadii.full,
+                  ),
+                  const SizedBox(height: 24),
+                  // Materials card (replaces tabs)
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.stackGap),
+                    decoration: _cardDecoration(scheme),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Materials',
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: scheme.onSurfaceVariant,
+                                fontWeight: FontWeight.bold,
                               ),
-                              border: Border.all(
-                                color: scheme.primary.withOpacity(0.18),
-                              ),
-                            ),
+                        ),
+                        const SizedBox(height: 12),
+                        if (materials.isEmpty)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 8),
                             child: Text(
-                              'MODULE ${widget.course.modulesCompleted.toString().padLeft(2, '0')}',
+                              'No materials available',
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: scheme.onSurfaceVariant),
+                            ),
+                          )
+                        else
+                          ...materials.map((mat) {
+                            return Padding(
+                              padding: const EdgeInsets.only(bottom: 12),
+                              child: ListTile(
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 14,
+                                  vertical: 6,
+                                ),
+                                onTap: () => widget.onSummarizeMaterial(mat),
+                                leading: Container(
+                                  padding: const EdgeInsets.all(10),
+                                  decoration: BoxDecoration(
+                                    color: scheme.primary.withOpacity(0.12),
+                                    borderRadius: BorderRadius.circular(14),
+                                  ),
+                                  child: Icon(
+                                    Icons.picture_as_pdf_rounded,
+                                    color: scheme.primary,
+                                    size: 18,
+                                  ),
+                                ),
+                                title: Text(
+                                  mat.title,
+                                  style: Theme.of(context).textTheme.bodyMedium
+                                      ?.copyWith(
+                                        color: scheme.onSurface,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                ),
+                                subtitle: Text(
+                                  'Size: ${mat.size}  •  Time: ${mat.time}',
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(
+                                        color: scheme.onSurfaceVariant,
+                                      ),
+                                ),
+                                trailing: TextButton.icon(
+                                  onPressed: () =>
+                                      widget.onSummarizeMaterial(mat),
+                                  style: TextButton.styleFrom(
+                                    foregroundColor: scheme.primary,
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 10,
+                                      vertical: 8,
+                                    ),
+                                    minimumSize: Size.zero,
+                                    tapTargetSize:
+                                        MaterialTapTargetSize.shrinkWrap,
+                                  ),
+                                  icon: const Icon(
+                                    Icons.visibility_outlined,
+                                    size: 16,
+                                  ),
+                                  label: const Text('View'),
+                                ),
+                              ),
+                            );
+                          }),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  // AI helper panel
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.stackGap),
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          scheme.primaryContainer.withOpacity(0.22),
+                          scheme.secondaryContainer.withOpacity(0.16),
+                        ],
+                      ),
+                      borderRadius: BorderRadius.circular(AppRadii.xl),
+                      boxShadow: [
+                        BoxShadow(
+                          color: scheme.primary.withOpacity(0.08),
+                          blurRadius: 18,
+                          offset: const Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.auto_awesome,
+                              color: scheme.primary,
+                              size: 18,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              'UNI LEARN AI ASSISTANT',
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
                                     color: scheme.primary,
-                                    fontWeight: FontWeight.w700,
-                                    fontSize: 10,
+                                    fontWeight: FontWeight.w900,
+                                    fontSize: 16,
+                                    letterSpacing: 1.0,
                                   ),
                             ),
-                          ),
-                          const SizedBox(height: 9),
-                          Text(
-                            widget.course.title,
-                            style: Theme.of(context).textTheme.titleLarge
-                                ?.copyWith(
-                                  color: scheme.onSurface,
-                                  fontWeight: FontWeight.w800,
-                                ),
-                          ),
-                          const SizedBox(height: 6),
-                          Text(
-                            'Advanced Neural Networks and Deep Learning architectures for real-world predictive modeling.',
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(color: scheme.onSurfaceVariant),
-                          ),
-                          const SizedBox(height: 18),
-                          Row(
-                            children: [
-                              Expanded(
-                                child: _buildHeroActionButton(
-                                  context,
-                                  icon: Icons.play_arrow_rounded,
-                                  label: 'Continue learning',
-                                  isPrimary: true,
-                                  onPressed: () {},
-                                ),
-                              ),
-                              const SizedBox(width: 12),
-                              Expanded(
-                                child: _buildHeroActionButton(
-                                  context,
-                                  icon: Icons.menu_book_outlined,
-                                  label: 'Syllabus',
-                                  isPrimary: false,
-                                  onPressed: () {},
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 24),
-              // Activity metrics
-              Container(
-                padding: const EdgeInsets.all(AppSpacing.stackGap),
-                decoration: _cardDecoration(scheme),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'COURSE ACTIVITY',
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: scheme.onSurfaceVariant,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Time Spent',
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(color: scheme.onSurfaceVariant),
+                          ],
                         ),
+                        const SizedBox(height: 12),
                         Text(
-                          '${widget.course.timeSpentHours}h',
+                          '"I noticed you\'re reviewing CNNs. Would you like me to generate a summary of the AlexNet vs VGG architectures from today\'s lecture?"',
                           style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
-                                color: scheme.primary,
-                                fontWeight: FontWeight.bold,
+                                color: scheme.onSurfaceVariant,
+                                fontStyle: FontStyle.italic,
                               ),
                         ),
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(AppRadii.full),
-                      child: LinearProgressIndicator(
-                        value: widget.course.progressPercentage / 100.0,
-                        minHeight: 8,
-                        backgroundColor: scheme.surface.withOpacity(0.20),
-                        valueColor: AlwaysStoppedAnimation<Color>(
-                          scheme.primary,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 14),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Average Grade',
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(color: scheme.onSurfaceVariant),
-                        ),
-                        Text(
-                          widget.course.averageGrade,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: scheme.secondary,
-                                fontWeight: FontWeight.bold,
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: scheme.primary.withOpacity(
+                                  0.16,
+                                ),
+                                shadowColor: Colors.transparent,
+                                side: BorderSide(
+                                  color: scheme.primary.withOpacity(0.24),
+                                ),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 10,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(
+                                    AppRadii.md,
+                                  ),
+                                ),
                               ),
+                              onPressed: widget.onAssistantAsk,
+                              child: Text(
+                                'Yes, summarize',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: scheme.primary,
+                                      fontSize: 16,
+                                    ),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            TextButton(
+                              onPressed: () {},
+                              child: Text(
+                                'Not now',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: scheme.onSurfaceVariant,
+                                      fontSize: 12,
+                                    ),
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
-                    const SizedBox(height: 14),
-                    Divider(color: scheme.onSurface.withOpacity(0.08)),
-                    const SizedBox(height: 14),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceAround,
-                      children: [
-                        _buildMetricCol(
-                          widget.course.badgesCount.toString(),
-                          'Badges',
-                        ),
-                        _buildMetricCol(
-                          widget.course.modulesCompleted.toString().padLeft(
-                            2,
-                            '0',
-                          ),
-                          'Completed',
-                        ),
-                        _buildMetricCol(
-                          widget.course.projectsCount.toString(),
-                          'Projects',
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 24),
-              // Material tabs
-              TabBar(
-                controller: _tabController,
-                dividerColor: Colors.transparent,
-                indicatorSize: TabBarIndicatorSize.label,
-                indicatorWeight: 3,
-                indicatorColor: scheme.primary,
-                labelColor: scheme.primary,
-                unselectedLabelColor: scheme.onSurfaceVariant,
-                tabs: const [
-                  Tab(text: 'Materials'),
-                  Tab(text: 'Deadlines'),
+                  ),
                 ],
               ),
-              const SizedBox(height: 16),
-              // Materials list
-              ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: widget.materials.length,
-                itemBuilder: (context, idx) {
-                  final mat = widget.materials[idx];
-                  return Container(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    decoration: _cardDecoration(scheme),
-                    child: ListTile(
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 14,
-                        vertical: 6,
-                      ),
-                      onTap: () => widget.onSummarizeMaterial(mat),
-                      leading: Container(
-                        padding: const EdgeInsets.all(10),
-                        decoration: BoxDecoration(
-                          color: scheme.primary.withOpacity(0.12),
-                          borderRadius: BorderRadius.circular(14),
-                        ),
-                        child: Icon(
-                          mat.type == 'pdf'
-                              ? Icons.description
-                              : Icons.play_circle_outline,
-                          color: scheme.primary,
-                          size: 18,
-                        ),
-                      ),
-                      title: Text(
-                        mat.title,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: scheme.onSurface,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      subtitle: Text(
-                        mat.sizeOrDuration,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: scheme.onSurfaceVariant,
-                        ),
-                      ),
-                      trailing: Icon(
-                        Icons.download_rounded,
-                        color: scheme.onSurfaceVariant,
-                      ),
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(height: 24),
-              // AI helper panel
-              Container(
-                padding: const EdgeInsets.all(AppSpacing.stackGap),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      scheme.primaryContainer.withOpacity(0.22),
-                      scheme.secondaryContainer.withOpacity(0.16),
-                    ],
-                  ),
-                  borderRadius: BorderRadius.circular(AppRadii.xl),
-                  boxShadow: [
-                    BoxShadow(
-                      color: scheme.primary.withOpacity(0.08),
-                      blurRadius: 18,
-                      offset: const Offset(0, 8),
-                    ),
-                  ],
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Icon(
-                          Icons.auto_awesome,
-                          color: scheme.primary,
-                          size: 18,
-                        ),
-                        const SizedBox(width: 8),
-                        Text(
-                          'UNI LEARN AI ASSISTANT',
-                          style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: scheme.primary,
-                                fontWeight: FontWeight.w900,
-                                fontSize: 16,
-                                letterSpacing: 1.0,
-                              ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      '"I noticed you\'re reviewing CNNs. Would you like me to generate a summary of the AlexNet vs VGG architectures from today\'s lecture?"',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: scheme.onSurfaceVariant,
-                        fontStyle: FontStyle.italic,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: scheme.primary.withOpacity(0.16),
-                            shadowColor: Colors.transparent,
-                            side: BorderSide(
-                              color: scheme.primary.withOpacity(0.24),
-                            ),
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 12,
-                              vertical: 10,
-                            ),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(AppRadii.md),
-                            ),
-                          ),
-                          onPressed: widget.onAssistantAsk,
-                          child: Text(
-                            'Yes, summarize',
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(color: scheme.primary, fontSize: 16),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        TextButton(
-                          onPressed: () {},
-                          child: Text(
-                            'Not now',
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(
-                                  color: scheme.onSurfaceVariant,
-                                  fontSize: 12,
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ],
+            ),
           ),
-        ),
+        ],
       ),
-      ],
-    ),
-  );
+    );
   }
 
   BoxDecoration _cardDecoration(ColorScheme scheme) {

--- a/apps/mobile/lib/features/courses/presentation/course_detail_screen.dart
+++ b/apps/mobile/lib/features/courses/presentation/course_detail_screen.dart
@@ -1,44 +1,651 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:mobile/core/testing/mock_catalog.dart';
+import 'package:mobile/theme/app_radii.dart';
 import 'package:mobile/theme/app_spacing.dart';
 
-class CourseDetailScreen extends StatelessWidget {
-  const CourseDetailScreen({super.key, required this.courseId});
+// Model definitions
+class Course {
+  final String id;
+  final String title;
+  final String code;
+  final int progressPercentage;
+  final int modulesCompleted;
+  final int totalModules;
+  final double timeSpentHours;
+  final String averageGrade;
+  final int badgesCount;
+  final int projectsCount;
 
-  final String courseId;
+  const Course({
+    required this.id,
+    required this.title,
+    required this.code,
+    required this.progressPercentage,
+    required this.modulesCompleted,
+    required this.totalModules,
+    required this.timeSpentHours,
+    required this.averageGrade,
+    required this.badgesCount,
+    required this.projectsCount,
+  });
+}
+
+class LectureMaterial {
+  final String id;
+  final String title;
+  final String type; // 'pdf' | 'video' | 'lab'
+  final String sizeOrDuration;
+
+  const LectureMaterial({
+    required this.id,
+    required this.title,
+    required this.type,
+    required this.sizeOrDuration,
+  });
+}
+
+class CourseDetailsScreen extends StatefulWidget {
+  final Course course;
+  final List<LectureMaterial> materials;
+  final VoidCallback onBack;
+  final Function(LectureMaterial) onSummarizeMaterial;
+  final VoidCallback onAssistantAsk;
+
+  const CourseDetailsScreen({
+    Key? key,
+    required this.course,
+    required this.materials,
+    required this.onBack,
+    required this.onSummarizeMaterial,
+    required this.onAssistantAsk,
+  }) : super(key: key);
+
+  @override
+  State<CourseDetailsScreen> createState() => _CourseDetailsScreenState();
+}
+
+class _CourseDetailsScreenState extends State<CourseDetailsScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  static const _bottomBackgroundImageUrl =
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuB8eEmwxGtwcZGuL78pXL9F0XDxuX3q6KfZUCJdg2R2Z4DGNAfqI5P0o3JMNlGcjljZX0xrScWv5bE_7oSNOfmsnqzY6kQSF71qfYoSJUT-MfRlBxz9b-K1-IV8CSZLu1eCgE2h4mnFS7-HppKZ_NvF6UAjj4Gcop51PKeZI1aY-scIILL8smc6-Ywq8H1hcYh2twu2x6Tv3RPGTYDSd0PVGuX4exp7hPoc6C5wAE9aPYqHSwvBdBWIVXsYNWq3-pm0Zup2Oo577RJm';
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final course = MockCatalog.courseById(courseId);
+    final scheme = Theme.of(context).colorScheme;
 
     return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
+        backgroundColor: scheme.surfaceVariant,
+        elevation: 0,
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
+          icon: Icon(Icons.arrow_back, color: scheme.onSurface),
+          onPressed: widget.onBack,
         ),
-        title: Text(course?.name ?? 'Course'),
+        title: Text(
+          'Course Panel',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        centerTitle: false,
+        actions: [
+          IconButton(
+            icon: Icon(Icons.notifications, color: scheme.primary, size: 20),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: course == null
-          ? Center(child: Text('Unknown course: $courseId', style: Theme.of(context).textTheme.bodyLarge))
-          : ListView(
-              padding: const EdgeInsets.all(AppSpacing.containerPadding),
-              children: [
-                Text(course.name, style: Theme.of(context).textTheme.headlineSmall),
-                const SizedBox(height: 8),
-                Text('Code: ${course.code}', style: Theme.of(context).textTheme.bodyLarge),
-                const SizedBox(height: 8),
-                Text('Department: ${course.departmentId}', style: Theme.of(context).textTheme.bodyMedium),
-                const SizedBox(height: 8),
-                Text('Year: ${course.academicYear}', style: Theme.of(context).textTheme.bodyMedium),
-                const SizedBox(height: 24),
-                Text(
-                  'Detail modules and resources will load from the API using this course id.',
-                  style: Theme.of(context).textTheme.bodySmall,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                width: double.infinity,
+                height: 320,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Image.network(
+                      _bottomBackgroundImageUrl,
+                      fit: BoxFit.cover,
+                      alignment: Alignment.bottomCenter,
+                      errorBuilder: (context, error, stackTrace) {
+                        return const SizedBox.shrink();
+                      },
+                    ),
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            scheme.surface.withValues(alpha: 0.00),
+                            scheme.surface.withValues(alpha: 0.52),
+                            scheme.surface.withValues(alpha: 0.88),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
+          ),
+          SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.containerPadding),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+              // Hero Progress banner
+              Container(
+                constraints: const BoxConstraints(minHeight: 252),
+                padding: const EdgeInsets.all(AppSpacing.stackGap),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      scheme.surfaceContainerHighest.withOpacity(0.92),
+                      scheme.surfaceContainerHigh.withOpacity(0.72),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(AppRadii.xl),
+                  border: Border.all(color: scheme.primary.withOpacity(0.10)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: scheme.shadow.withOpacity(0.08),
+                      blurRadius: 24,
+                      offset: const Offset(0, 10),
+                    ),
+                  ],
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        Container(
+                          width: 108,
+                          height: 108,
+                          decoration: BoxDecoration(
+                            color: scheme.primary.withOpacity(0.08),
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        SizedBox(
+                          width: 96,
+                          height: 96,
+                          child: CircularProgressIndicator(
+                            value: widget.course.progressPercentage / 100.0,
+                            strokeWidth: 6.5,
+                            strokeCap: StrokeCap.round,
+                            backgroundColor: scheme.surface.withOpacity(0.22),
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              scheme.primary,
+                            ),
+                          ),
+                        ),
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              '${widget.course.progressPercentage}%',
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    color: scheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                            ),
+                            Text(
+                              'COMPLETE',
+                              style: Theme.of(context).textTheme.labelSmall
+                                  ?.copyWith(
+                                    color: scheme.onSurfaceVariant,
+                                    fontSize: 10,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(width: 22),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 5,
+                            ),
+                            decoration: BoxDecoration(
+                              color: scheme.primary.withOpacity(0.12),
+                              borderRadius: BorderRadius.circular(
+                                AppRadii.full,
+                              ),
+                              border: Border.all(
+                                color: scheme.primary.withOpacity(0.18),
+                              ),
+                            ),
+                            child: Text(
+                              'MODULE ${widget.course.modulesCompleted.toString().padLeft(2, '0')}',
+                              style: Theme.of(context).textTheme.labelSmall
+                                  ?.copyWith(
+                                    color: scheme.primary,
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 10,
+                                  ),
+                            ),
+                          ),
+                          const SizedBox(height: 9),
+                          Text(
+                            widget.course.title,
+                            style: Theme.of(context).textTheme.titleLarge
+                                ?.copyWith(
+                                  color: scheme.onSurface,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            'Advanced Neural Networks and Deep Learning architectures for real-world predictive modeling.',
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(color: scheme.onSurfaceVariant),
+                          ),
+                          const SizedBox(height: 18),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: _buildHeroActionButton(
+                                  context,
+                                  icon: Icons.play_arrow_rounded,
+                                  label: 'Continue learning',
+                                  isPrimary: true,
+                                  onPressed: () {},
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: _buildHeroActionButton(
+                                  context,
+                                  icon: Icons.menu_book_outlined,
+                                  label: 'Syllabus',
+                                  isPrimary: false,
+                                  onPressed: () {},
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              // Activity metrics
+              Container(
+                padding: const EdgeInsets.all(AppSpacing.stackGap),
+                decoration: _cardDecoration(scheme),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'COURSE ACTIVITY',
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          'Time Spent',
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(color: scheme.onSurfaceVariant),
+                        ),
+                        Text(
+                          '${widget.course.timeSpentHours}h',
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: scheme.primary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(AppRadii.full),
+                      child: LinearProgressIndicator(
+                        value: widget.course.progressPercentage / 100.0,
+                        minHeight: 8,
+                        backgroundColor: scheme.surface.withOpacity(0.20),
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          scheme.primary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          'Average Grade',
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(color: scheme.onSurfaceVariant),
+                        ),
+                        Text(
+                          widget.course.averageGrade,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: scheme.secondary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+                    Divider(color: scheme.onSurface.withOpacity(0.08)),
+                    const SizedBox(height: 14),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        _buildMetricCol(
+                          widget.course.badgesCount.toString(),
+                          'Badges',
+                        ),
+                        _buildMetricCol(
+                          widget.course.modulesCompleted.toString().padLeft(
+                            2,
+                            '0',
+                          ),
+                          'Completed',
+                        ),
+                        _buildMetricCol(
+                          widget.course.projectsCount.toString(),
+                          'Projects',
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              // Material tabs
+              TabBar(
+                controller: _tabController,
+                dividerColor: Colors.transparent,
+                indicatorSize: TabBarIndicatorSize.label,
+                indicatorWeight: 3,
+                indicatorColor: scheme.primary,
+                labelColor: scheme.primary,
+                unselectedLabelColor: scheme.onSurfaceVariant,
+                tabs: const [
+                  Tab(text: 'Materials'),
+                  Tab(text: 'Deadlines'),
+                ],
+              ),
+              const SizedBox(height: 16),
+              // Materials list
+              ListView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: widget.materials.length,
+                itemBuilder: (context, idx) {
+                  final mat = widget.materials[idx];
+                  return Container(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    decoration: _cardDecoration(scheme),
+                    child: ListTile(
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 6,
+                      ),
+                      onTap: () => widget.onSummarizeMaterial(mat),
+                      leading: Container(
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color: scheme.primary.withOpacity(0.12),
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                        child: Icon(
+                          mat.type == 'pdf'
+                              ? Icons.description
+                              : Icons.play_circle_outline,
+                          color: scheme.primary,
+                          size: 18,
+                        ),
+                      ),
+                      title: Text(
+                        mat.title,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: scheme.onSurface,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      subtitle: Text(
+                        mat.sizeOrDuration,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: scheme.onSurfaceVariant,
+                        ),
+                      ),
+                      trailing: Icon(
+                        Icons.download_rounded,
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 24),
+              // AI helper panel
+              Container(
+                padding: const EdgeInsets.all(AppSpacing.stackGap),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      scheme.primaryContainer.withOpacity(0.22),
+                      scheme.secondaryContainer.withOpacity(0.16),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(AppRadii.xl),
+                  boxShadow: [
+                    BoxShadow(
+                      color: scheme.primary.withOpacity(0.08),
+                      blurRadius: 18,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.auto_awesome,
+                          color: scheme.primary,
+                          size: 18,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'UNI LEARN AI ASSISTANT',
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: scheme.primary,
+                                fontWeight: FontWeight.w900,
+                                fontSize: 16,
+                                letterSpacing: 1.0,
+                              ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      '"I noticed you\'re reviewing CNNs. Would you like me to generate a summary of the AlexNet vs VGG architectures from today\'s lecture?"',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: scheme.primary.withOpacity(0.16),
+                            shadowColor: Colors.transparent,
+                            side: BorderSide(
+                              color: scheme.primary.withOpacity(0.24),
+                            ),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 10,
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(AppRadii.md),
+                            ),
+                          ),
+                          onPressed: widget.onAssistantAsk,
+                          child: Text(
+                            'Yes, summarize',
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: scheme.primary, fontSize: 16),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        TextButton(
+                          onPressed: () {},
+                          child: Text(
+                            'Not now',
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
+                                  color: scheme.onSurfaceVariant,
+                                  fontSize: 12,
+                                ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      ],
+    ),
+  );
+  }
+
+  BoxDecoration _cardDecoration(ColorScheme scheme) {
+    return BoxDecoration(
+      gradient: LinearGradient(
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+        colors: [
+          scheme.surfaceContainer.withOpacity(0.88),
+          scheme.surfaceContainerLow.withOpacity(0.72),
+        ],
+      ),
+      borderRadius: BorderRadius.circular(AppRadii.xl),
+      border: Border.all(color: scheme.outline.withOpacity(0.08)),
+      boxShadow: [
+        BoxShadow(
+          color: scheme.shadow.withOpacity(0.06),
+          blurRadius: 18,
+          offset: const Offset(0, 8),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeroActionButton(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required bool isPrimary,
+    required VoidCallback onPressed,
+  }) {
+    final scheme = Theme.of(context).colorScheme;
+    final baseStyle = ElevatedButton.styleFrom(
+      elevation: 0,
+      minimumSize: const Size.fromHeight(48),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadii.md),
+      ),
+      textStyle: Theme.of(context).textTheme.labelLarge?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.2,
+      ),
+    );
+
+    return ElevatedButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 18),
+      label: Text(label),
+      style: baseStyle.copyWith(
+        backgroundColor: WidgetStatePropertyAll(
+          isPrimary ? scheme.primary : scheme.surfaceContainerHighest,
+        ),
+        foregroundColor: WidgetStatePropertyAll(
+          isPrimary ? scheme.onPrimary : scheme.primary,
+        ),
+        side: WidgetStatePropertyAll(
+          BorderSide(
+            color: isPrimary
+                ? scheme.primary.withOpacity(0.24)
+                : scheme.primary.withOpacity(0.20),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetricCol(String val, String label) {
+    final scheme = Theme.of(context).colorScheme;
+    return Column(
+      children: [
+        Text(
+          val,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: scheme.primary,
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          label.toUpperCase(),
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: scheme.onSurfaceVariant,
+            fontSize: 10,
+            letterSpacing: 0.5,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/courses/presentation/courses_screen.dart
+++ b/apps/mobile/lib/features/courses/presentation/courses_screen.dart
@@ -4,8 +4,86 @@ import 'package:mobile/core/testing/mock_catalog.dart';
 import 'package:mobile/theme/app_radii.dart';
 import 'package:mobile/theme/app_spacing.dart';
 
-class CoursesScreen extends StatelessWidget {
+class CoursesScreen extends StatefulWidget {
   const CoursesScreen({super.key});
+
+  @override
+  State<CoursesScreen> createState() => _CoursesScreenState();
+}
+
+class _YearTag extends StatelessWidget {
+  const _YearTag({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    Key? key,
+  }) : super(key: key);
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 220),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            gradient: selected
+                ? LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      scheme.primary,
+                      scheme.primary.withValues(alpha: 0.88),
+                    ],
+                  )
+                : null,
+            color: selected
+                ? null
+                : scheme.surfaceVariant.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: selected
+                ? [
+                    BoxShadow(
+                      color: scheme.primary.withValues(alpha: 0.12),
+                      blurRadius: 12,
+                      offset: const Offset(0, 6),
+                    ),
+                  ]
+                : null,
+            border: Border.all(
+              color: selected
+                  ? scheme.primary.withValues(alpha: 0.18)
+                  : scheme.outline.withValues(alpha: 0.06),
+            ),
+          ),
+          child: Text(
+            label,
+            style: selected
+                ? Theme.of(context).textTheme.labelLarge?.copyWith(
+                    color: scheme.onPrimary,
+                    fontWeight: FontWeight.w800,
+                  )
+                : Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: scheme.onSurface,
+                    fontWeight: FontWeight.w700,
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CoursesScreenState extends State<CoursesScreen> {
+  int? _selectedYear;
 
   Color _accentForIndex(int index) {
     const accents = [
@@ -21,318 +99,324 @@ class CoursesScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
 
-    return ListView.separated(
-      padding: const EdgeInsets.all(AppSpacing.containerPadding),
-      itemCount: MockCatalog.apiCourses.length,
-      separatorBuilder: (context, index) => const SizedBox(height: 12),
-      itemBuilder: (context, i) {
-        final c = MockCatalog.apiCourses[i];
-        final summary = MockCatalog.enrolledSummaries
-            .where((item) => item.courseId == c.id)
-            .firstOrNull;
-        final progressPercent = summary?.progressPercent ?? 0;
-        final accent = _accentForIndex(i);
+    final years = [1, 2, 3, 4];
+    final List<int?> tags = [null, ...years]; // null represents 'All'
+    final filtered = _selectedYear == null
+        ? MockCatalog.apiCourses
+        : MockCatalog.apiCourses
+              .where((course) => course.academicYear == _selectedYear)
+              .toList();
 
-        return SizedBox(
-          height: 214,
-          child: Material(
-            color: Colors.transparent,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(AppRadii.lg),
-              onTap: () => context.push('/courses/${c.id}'),
-              child: Container(
-                clipBehavior: Clip.antiAlias,
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      scheme.surfaceContainerLow,
-                      scheme.surfaceContainer.withValues(alpha: 0.96),
-                    ],
-                  ),
-                  borderRadius: BorderRadius.circular(AppRadii.lg),
-                  border: Border.all(
-                    color: scheme.outlineVariant.withValues(alpha: 0.35),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: scheme.shadow.withValues(alpha: 0.16),
-                      blurRadius: 28,
-                      offset: const Offset(0, 14),
-                    ),
-                  ],
-                ),
-                child: Stack(
-                  children: [
-                    Positioned(
-                      right: -18,
-                      top: -18,
-                      child: Container(
-                        width: 92,
-                        height: 92,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          gradient: RadialGradient(
-                            colors: [
-                              accent.withValues(alpha: 0.30),
-                              accent.withValues(alpha: 0.06),
-                              Colors.transparent,
-                            ],
-                          ),
-                        ),
+    return Column(
+      children: [
+        const SizedBox(height: 12),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.containerPadding,
+          ),
+          child: SizedBox(
+            height: 52,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: tags.map((t) {
+                  final isAll = t == null;
+                  final selected = isAll
+                      ? _selectedYear == null
+                      : _selectedYear == t;
+                  final label = isAll ? 'All' : 'Year $t';
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: _YearTag(
+                      label: label,
+                      selected: selected,
+                      onTap: () => setState(
+                        () => _selectedYear = isAll ? null : t,
                       ),
                     ),
-                    Positioned(
-                      left: -16,
-                      bottom: -18,
-                      child: Container(
-                        width: 84,
-                        height: 84,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          gradient: RadialGradient(
-                            colors: [
-                              scheme.primary.withValues(alpha: 0.18),
-                              scheme.primary.withValues(alpha: 0.04),
-                              Colors.transparent,
-                            ],
-                          ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.all(AppSpacing.containerPadding),
+            itemCount: filtered.length,
+            separatorBuilder: (context, index) => const SizedBox(height: 12),
+            itemBuilder: (context, i) {
+              final c = filtered[i];
+              final summary = MockCatalog.enrolledSummaries
+                  .where((item) => item.courseId == c.id)
+                  .firstOrNull;
+              final progressPercent = summary?.progressPercent ?? 0;
+              final originalIndex = MockCatalog.apiCourses.indexWhere(
+                (x) => x.id == c.id,
+              );
+              final accent = _accentForIndex(originalIndex);
+
+              return SizedBox(
+                height: 214,
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(AppRadii.lg),
+                    onTap: () => context.push('/courses/${c.id}'),
+                    child: Container(
+                      clipBehavior: Clip.antiAlias,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                          colors: [
+                            scheme.surfaceContainerLow,
+                            scheme.surfaceContainer.withValues(alpha: 0.96),
+                          ],
                         ),
+                        borderRadius: BorderRadius.circular(AppRadii.lg),
+                        border: Border.all(
+                          color: scheme.outlineVariant.withValues(alpha: 0.35),
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: scheme.shadow.withValues(alpha: 0.16),
+                            blurRadius: 28,
+                            offset: const Offset(0, 14),
+                          ),
+                        ],
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                      child: Stack(
                         children: [
-                          Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 12,
-                                        vertical: 6,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: accent.withValues(alpha: 0.14),
-                                        borderRadius: BorderRadius.circular(
-                                          AppRadii.full,
-                                        ),
-                                        border: Border.all(
-                                          color: accent.withValues(alpha: 0.22),
-                                        ),
-                                      ),
-                                      child: Text(
-                                        c.code,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .labelSmall
-                                            ?.copyWith(
-                                              color: accent,
-                                              fontWeight: FontWeight.w800,
-                                              letterSpacing: 0.5,
-                                            ),
-                                      ),
-                                    ),
-                                    const SizedBox(height: 10),
-                                    Text(
-                                      c.name,
-                                      maxLines: 2,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .titleMedium
-                                          ?.copyWith(
-                                            fontWeight: FontWeight.w800,
-                                            height: 1.1,
-                                          ),
-                                    ),
-                                    const SizedBox(height: 8),
-                                    Text(
-                                      '${c.displayLevel} • ${c.departmentId} department',
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .bodySmall
-                                          ?.copyWith(
-                                            color: scheme.onSurfaceVariant,
-                                          ),
-                                    ),
+                          Positioned(
+                            right: -18,
+                            top: -18,
+                            child: Container(
+                              width: 92,
+                              height: 92,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                gradient: RadialGradient(
+                                  colors: [
+                                    accent.withValues(alpha: 0.30),
+                                    accent.withValues(alpha: 0.06),
+                                    Colors.transparent,
                                   ],
                                 ),
                               ),
-                              const SizedBox(width: 12),
-                              SizedBox(
-                                width: 58,
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.end,
+                            ),
+                          ),
+                          Positioned(
+                            left: -16,
+                            bottom: -18,
+                            child: Container(
+                              width: 84,
+                              height: 84,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                gradient: RadialGradient(
+                                  colors: [
+                                    scheme.primary.withValues(alpha: 0.18),
+                                    scheme.primary.withValues(alpha: 0.04),
+                                    Colors.transparent,
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
-                                    SizedBox(
-                                      width: 48,
-                                      height: 48,
-                                      child: Stack(
-                                        alignment: Alignment.center,
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
                                         children: [
-                                          CircularProgressIndicator(
-                                            value: progressPercent / 100,
-                                            strokeWidth: 3.6,
-                                            backgroundColor:
-                                                scheme.surfaceContainerHighest,
-                                            color: accent,
+                                          Container(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 12,
+                                              vertical: 6,
+                                            ),
+                                            decoration: BoxDecoration(
+                                              color: accent.withValues(
+                                                alpha: 0.14,
+                                              ),
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                    AppRadii.full,
+                                                  ),
+                                              border: Border.all(
+                                                color: accent.withValues(
+                                                  alpha: 0.22,
+                                                ),
+                                              ),
+                                            ),
+                                            child: Text(
+                                              c.code,
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .labelSmall
+                                                  ?.copyWith(
+                                                    color: accent,
+                                                    fontWeight: FontWeight.w800,
+                                                    letterSpacing: 0.5,
+                                                  ),
+                                            ),
                                           ),
+                                          const SizedBox(height: 10),
                                           Text(
-                                            '$progressPercent%',
+                                            c.name,
+                                            maxLines: 2,
+                                            overflow: TextOverflow.ellipsis,
                                             style: Theme.of(context)
                                                 .textTheme
-                                                .labelSmall
+                                                .titleMedium
                                                 ?.copyWith(
                                                   fontWeight: FontWeight.w800,
+                                                  height: 1.1,
+                                                ),
+                                          ),
+                                          const SizedBox(height: 8),
+                                          Text(
+                                            '${c.displayLevel} • ${c.departmentId} department',
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .bodySmall
+                                                ?.copyWith(
+                                                  color:
+                                                      scheme.onSurfaceVariant,
                                                 ),
                                           ),
                                         ],
                                       ),
                                     ),
-                                    const SizedBox(height: 6),
-                                    Text(
-                                      'progress',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .labelSmall
-                                          ?.copyWith(
-                                            color: scheme.onSurfaceVariant,
-                                            fontSize: 10,
+                                    const SizedBox(width: 12),
+                                    SizedBox(
+                                      width: 58,
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.end,
+                                        children: [
+                                          SizedBox(
+                                            width: 48,
+                                            height: 48,
+                                            child: Stack(
+                                              alignment: Alignment.center,
+                                              children: [
+                                                CircularProgressIndicator(
+                                                  value: progressPercent / 100,
+                                                  strokeWidth: 3.6,
+                                                  backgroundColor: scheme
+                                                      .surfaceContainerHighest,
+                                                  color: accent,
+                                                ),
+                                                Text(
+                                                  '$progressPercent%',
+                                                  style: Theme.of(context)
+                                                      .textTheme
+                                                      .labelSmall
+                                                      ?.copyWith(
+                                                        fontWeight:
+                                                            FontWeight.w800,
+                                                      ),
+                                                ),
+                                              ],
+                                            ),
                                           ),
+                                          const SizedBox(height: 6),
+                                          Text(
+                                            'progress',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .labelSmall
+                                                ?.copyWith(
+                                                  color:
+                                                      scheme.onSurfaceVariant,
+                                                  fontSize: 10,
+                                                ),
+                                          ),
+                                        ],
+                                      ),
                                     ),
                                   ],
                                 ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 14),
-                          Wrap(
-                            spacing: 8,
-                            runSpacing: 8,
-                            children: [
-                              _InfoChip(
-                                label: c.displayLevel,
-                                scheme: scheme,
-                                accent: accent,
-                              ),
-                              _InfoChip(
-                                label: 'Year ${c.academicYear}',
-                                scheme: scheme,
-                                accent: accent,
-                              ),
-                              _InfoChip(
-                                label: c.departmentId,
-                                scheme: scheme,
-                                accent: accent,
-                              ),
-                            ],
-                          ),
-                          const Spacer(),
-                          Row(
-                            children: [
-                              Icon(
-                                Icons.school_outlined,
-                                size: 18,
-                                color: scheme.onSurfaceVariant,
-                              ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: Text(
-                                  'Instructor ${c.instructorId}',
-                                  overflow: TextOverflow.ellipsis,
-                                  style: Theme.of(context).textTheme.bodySmall
-                                      ?.copyWith(fontWeight: FontWeight.w600),
-                                ),
-                              ),
-                              const SizedBox(width: 10),
-                              Container(
-                                width: 36,
-                                height: 36,
-                                decoration: BoxDecoration(
-                                  gradient: LinearGradient(
-                                    begin: Alignment.topLeft,
-                                    end: Alignment.bottomRight,
-                                    colors: [
-                                      accent,
-                                      accent.withValues(alpha: 0.72),
-                                    ],
-                                  ),
-                                  shape: BoxShape.circle,
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: accent.withValues(alpha: 0.28),
-                                      blurRadius: 14,
-                                      offset: const Offset(0, 8),
+                                const SizedBox(height: 14),
+                                const Spacer(),
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.school_outlined,
+                                      size: 18,
+                                      color: scheme.onSurfaceVariant,
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Expanded(
+                                      child: Text(
+                                        'Instructor ${c.instructorId}',
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 10),
+                                    Container(
+                                      width: 36,
+                                      height: 36,
+                                      decoration: BoxDecoration(
+                                        gradient: LinearGradient(
+                                          begin: Alignment.topLeft,
+                                          end: Alignment.bottomRight,
+                                          colors: [
+                                            accent,
+                                            accent.withValues(alpha: 0.72),
+                                          ],
+                                        ),
+                                        shape: BoxShape.circle,
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: accent.withValues(
+                                              alpha: 0.28,
+                                            ),
+                                            blurRadius: 14,
+                                            offset: const Offset(0, 8),
+                                          ),
+                                        ],
+                                      ),
+                                      child: Icon(
+                                        Icons.arrow_forward_rounded,
+                                        size: 20,
+                                        color: scheme.onPrimary,
+                                      ),
                                     ),
                                   ],
                                 ),
-                                child: Icon(
-                                  Icons.arrow_forward_rounded,
-                                  size: 20,
-                                  color: scheme.onPrimary,
-                                ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ],
                       ),
                     ),
-                  ],
+                  ),
                 ),
-              ),
-            ),
+              );
+            },
           ),
-        );
-      },
-    );
-  }
-}
-
-class _InfoChip extends StatelessWidget {
-  const _InfoChip({
-    required this.label,
-    required this.scheme,
-    required this.accent,
-  });
-
-  final String label;
-  final ColorScheme scheme;
-  final Color accent;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            accent.withValues(alpha: 0.12),
-            scheme.surfaceContainerHighest.withValues(alpha: 0.92),
-          ],
         ),
-        borderRadius: BorderRadius.circular(AppRadii.full),
-        border: Border.all(color: accent.withValues(alpha: 0.18)),
-      ),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-          fontWeight: FontWeight.w700,
-          color: scheme.onSurface,
-        ),
-      ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/features/courses/presentation/courses_screen.dart
+++ b/apps/mobile/lib/features/courses/presentation/courses_screen.dart
@@ -1,28 +1,338 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile/core/testing/mock_catalog.dart';
+import 'package:mobile/theme/app_radii.dart';
 import 'package:mobile/theme/app_spacing.dart';
 
 class CoursesScreen extends StatelessWidget {
   const CoursesScreen({super.key});
 
+  Color _accentForIndex(int index) {
+    const accents = [
+      Color(0xFF4CD7F6),
+      Color(0xFFA078FF),
+      Color(0xFF7CFFB2),
+      Color(0xFFFFC86B),
+    ];
+    return accents[index % accents.length];
+  }
+
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
     return ListView.separated(
       padding: const EdgeInsets.all(AppSpacing.containerPadding),
       itemCount: MockCatalog.apiCourses.length,
       separatorBuilder: (context, index) => const SizedBox(height: 12),
       itemBuilder: (context, i) {
         final c = MockCatalog.apiCourses[i];
-        return ListTile(
-          tileColor: Theme.of(context).colorScheme.surfaceContainerLow,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          title: Text(c.name),
-          subtitle: Text('${c.code} · ${c.displayLevel}'),
-          trailing: const Icon(Icons.chevron_right),
-          onTap: () => context.push('/courses/${c.id}'),
+        final summary = MockCatalog.enrolledSummaries
+            .where((item) => item.courseId == c.id)
+            .firstOrNull;
+        final progressPercent = summary?.progressPercent ?? 0;
+        final accent = _accentForIndex(i);
+
+        return SizedBox(
+          height: 214,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(AppRadii.lg),
+              onTap: () => context.push('/courses/${c.id}'),
+              child: Container(
+                clipBehavior: Clip.antiAlias,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      scheme.surfaceContainerLow,
+                      scheme.surfaceContainer.withValues(alpha: 0.96),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(AppRadii.lg),
+                  border: Border.all(
+                    color: scheme.outlineVariant.withValues(alpha: 0.35),
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: scheme.shadow.withValues(alpha: 0.16),
+                      blurRadius: 28,
+                      offset: const Offset(0, 14),
+                    ),
+                  ],
+                ),
+                child: Stack(
+                  children: [
+                    Positioned(
+                      right: -18,
+                      top: -18,
+                      child: Container(
+                        width: 92,
+                        height: 92,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: RadialGradient(
+                            colors: [
+                              accent.withValues(alpha: 0.30),
+                              accent.withValues(alpha: 0.06),
+                              Colors.transparent,
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: -16,
+                      bottom: -18,
+                      child: Container(
+                        width: 84,
+                        height: 84,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: RadialGradient(
+                            colors: [
+                              scheme.primary.withValues(alpha: 0.18),
+                              scheme.primary.withValues(alpha: 0.04),
+                              Colors.transparent,
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 12,
+                                        vertical: 6,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: accent.withValues(alpha: 0.14),
+                                        borderRadius: BorderRadius.circular(
+                                          AppRadii.full,
+                                        ),
+                                        border: Border.all(
+                                          color: accent.withValues(alpha: 0.22),
+                                        ),
+                                      ),
+                                      child: Text(
+                                        c.code,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .labelSmall
+                                            ?.copyWith(
+                                              color: accent,
+                                              fontWeight: FontWeight.w800,
+                                              letterSpacing: 0.5,
+                                            ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 10),
+                                    Text(
+                                      c.name,
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium
+                                          ?.copyWith(
+                                            fontWeight: FontWeight.w800,
+                                            height: 1.1,
+                                          ),
+                                    ),
+                                    const SizedBox(height: 8),
+                                    Text(
+                                      '${c.displayLevel} • ${c.departmentId} department',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodySmall
+                                          ?.copyWith(
+                                            color: scheme.onSurfaceVariant,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              SizedBox(
+                                width: 58,
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.end,
+                                  children: [
+                                    SizedBox(
+                                      width: 48,
+                                      height: 48,
+                                      child: Stack(
+                                        alignment: Alignment.center,
+                                        children: [
+                                          CircularProgressIndicator(
+                                            value: progressPercent / 100,
+                                            strokeWidth: 3.6,
+                                            backgroundColor:
+                                                scheme.surfaceContainerHighest,
+                                            color: accent,
+                                          ),
+                                          Text(
+                                            '$progressPercent%',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .labelSmall
+                                                ?.copyWith(
+                                                  fontWeight: FontWeight.w800,
+                                                ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    const SizedBox(height: 6),
+                                    Text(
+                                      'progress',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelSmall
+                                          ?.copyWith(
+                                            color: scheme.onSurfaceVariant,
+                                            fontSize: 10,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 14),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: [
+                              _InfoChip(
+                                label: c.displayLevel,
+                                scheme: scheme,
+                                accent: accent,
+                              ),
+                              _InfoChip(
+                                label: 'Year ${c.academicYear}',
+                                scheme: scheme,
+                                accent: accent,
+                              ),
+                              _InfoChip(
+                                label: c.departmentId,
+                                scheme: scheme,
+                                accent: accent,
+                              ),
+                            ],
+                          ),
+                          const Spacer(),
+                          Row(
+                            children: [
+                              Icon(
+                                Icons.school_outlined,
+                                size: 18,
+                                color: scheme.onSurfaceVariant,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  'Instructor ${c.instructorId}',
+                                  overflow: TextOverflow.ellipsis,
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(fontWeight: FontWeight.w600),
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              Container(
+                                width: 36,
+                                height: 36,
+                                decoration: BoxDecoration(
+                                  gradient: LinearGradient(
+                                    begin: Alignment.topLeft,
+                                    end: Alignment.bottomRight,
+                                    colors: [
+                                      accent,
+                                      accent.withValues(alpha: 0.72),
+                                    ],
+                                  ),
+                                  shape: BoxShape.circle,
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: accent.withValues(alpha: 0.28),
+                                      blurRadius: 14,
+                                      offset: const Offset(0, 8),
+                                    ),
+                                  ],
+                                ),
+                                child: Icon(
+                                  Icons.arrow_forward_rounded,
+                                  size: 20,
+                                  color: scheme.onPrimary,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
         );
       },
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({
+    required this.label,
+    required this.scheme,
+    required this.accent,
+  });
+
+  final String label;
+  final ColorScheme scheme;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            accent.withValues(alpha: 0.12),
+            scheme.surfaceContainerHighest.withValues(alpha: 0.92),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(AppRadii.full),
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          fontWeight: FontWeight.w700,
+          color: scheme.onSurface,
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/features/home/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/home_screen.dart
@@ -1,6 +1,7 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mobile/core/providers/auth_session_provider.dart';
 import 'package:mobile/core/testing/mock_catalog.dart';
 import 'package:mobile/core/widgets/widgets.dart';
 import 'package:mobile/features/home/presentation/widgets/deadlines_section.dart';
@@ -19,8 +20,6 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final scheme = Theme.of(context).colorScheme;
-    final session = ref.watch(authSessionProvider);
-    final displayName = session.user?.name ?? MockCatalog.userFirstName;
 
     return Stack(
       fit: StackFit.expand,
@@ -47,13 +46,19 @@ class HomeScreen extends ConsumerWidget {
               child: Stack(
                 fit: StackFit.expand,
                 children: [
-                  Image.network(
-                    _bottomBackgroundImageUrl,
-                    fit: BoxFit.cover,
-                    alignment: Alignment.bottomCenter,
-                    errorBuilder: (context, error, stackTrace) {
-                      return const SizedBox.shrink();
-                    },
+                  ClipRect(
+                    child: ImageFiltered(
+                      imageFilter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                      child: Image.network(
+                        _bottomBackgroundImageUrl,
+                        fit: BoxFit.cover,
+                        alignment: Alignment.bottomCenter,
+                        filterQuality: FilterQuality.low,
+                        errorBuilder: (context, error, stackTrace) {
+                          return const SizedBox.shrink();
+                        },
+                      ),
+                    ),
                   ),
                   DecoratedBox(
                     decoration: BoxDecoration(
@@ -75,98 +80,7 @@ class HomeScreen extends ConsumerWidget {
         ),
         CustomScrollView(
           slivers: [
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.containerPadding,
-                  12,
-                  AppSpacing.containerPadding,
-                  18,
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    CircleAvatar(
-                      radius: 20,
-                      backgroundColor: scheme.primaryContainer,
-                      child: Text(
-                        displayName.isNotEmpty
-                            ? displayName[0].toUpperCase()
-                            : '?',
-                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                          color: scheme.onPrimaryContainer,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            '${MockCatalog.greeting},',
-                            style: Theme.of(context).textTheme.labelMedium
-                                ?.copyWith(
-                                  color: scheme.onSurfaceVariant,
-                                  letterSpacing: 0.8,
-                                ),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            displayName,
-                            style: Theme.of(context).textTheme.titleLarge
-                                ?.copyWith(
-                                  fontWeight: FontWeight.w800,
-                                  color: scheme.onSurface,
-                                ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Text(
-                          MockCatalog.brandTitle,
-                          style: Theme.of(context).textTheme.labelLarge
-                              ?.copyWith(
-                                color: scheme.secondary,
-                                fontWeight: FontWeight.w900,
-                                letterSpacing: 1.2,
-                              ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          'Keep learning',
-                          style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(color: scheme.onSurfaceVariant),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(width: 8),
-                    IconButton(
-                      onPressed: () {},
-                      icon: const Icon(Icons.notifications_none_rounded),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: Divider(
-                    height: 1,
-                    thickness: 1.75,
-                    color: scheme.outlineVariant.withValues(alpha: 0.42),
-                  ),
-                ),
-              ),
-            ),
-            const SliverToBoxAdapter(child: SizedBox(height: 14)),
+            const SliverToBoxAdapter(child: SizedBox(height: 12)),
             SliverPadding(
               padding: const EdgeInsets.symmetric(
                 horizontal: AppSpacing.containerPadding,

--- a/apps/mobile/lib/features/home/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/home_screen.dart
@@ -8,11 +8,13 @@ import 'package:mobile/features/home/presentation/widgets/enrolled_courses_secti
 import 'package:mobile/features/home/presentation/widgets/home_ai_card.dart';
 import 'package:mobile/features/home/presentation/widgets/quick_actions_grid.dart';
 import 'package:mobile/features/home/presentation/widgets/recent_activity_section.dart';
-import 'package:mobile/features/home/presentation/widgets/study_streak_banner.dart';
 import 'package:mobile/theme/app_spacing.dart';
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
+
+  static const _bottomBackgroundImageUrl =
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuB8eEmwxGtwcZGuL78pXL9F0XDxuX3q6KfZUCJdg2R2Z4DGNAfqI5P0o3JMNlGcjljZX0xrScWv5bE_7oSNOfmsnqzY6kQSF71qfYoSJUT-MfRlBxz9b-K1-IV8CSZLu1eCgE2h4mnFS7-HppKZ_NvF6UAjj4Gcop51PKeZI1aY-scIILL8smc6-Ywq8H1hcYh2twu2x6Tv3RPGTYDSd0PVGuX4exp7hPoc6C5wAE9aPYqHSwvBdBWIVXsYNWq3-pm0Zup2Oo577RJm';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -20,132 +22,489 @@ class HomeScreen extends ConsumerWidget {
     final session = ref.watch(authSessionProvider);
     final displayName = session.user?.name ?? MockCatalog.userFirstName;
 
-    return CustomScrollView(
-      slivers: [
-        SliverToBoxAdapter(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.containerPadding,
-              12,
-              AppSpacing.containerPadding,
-              AppSpacing.stackGap,
-            ),
-            child: Row(
-              children: [
-                CircleAvatar(
-                  radius: 22,
-                  backgroundColor: scheme.primaryContainer,
-                  child: Text(
-                    displayName.isNotEmpty ? displayName[0] : '?',
-                    style: TextStyle(color: scheme.onPrimaryContainer),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '${MockCatalog.greeting}, $displayName',
-                        style: Theme.of(context).textTheme.titleSmall,
-                      ),
-                      Text(
-                        MockCatalog.brandTitle,
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              color: scheme.secondary,
-                              fontWeight: FontWeight.w800,
-                            ),
-                      ),
-                    ],
-                  ),
-                ),
-                IconButton(
-                  onPressed: () {},
-                  icon: const Icon(Icons.notifications_none_rounded),
-                ),
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                scheme.surface,
+                scheme.surface.withValues(alpha: 0.96),
+                scheme.surfaceContainerLowest,
               ],
             ),
           ),
         ),
-        SliverPadding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.containerPadding),
-          sliver: SliverToBoxAdapter(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const StudyStreakBanner(days: MockCatalog.streakDays),
-                const SizedBox(height: AppSpacing.stackGap),
-                HomeAiCard(suggestion: MockCatalog.aiSuggestion),
-                const SizedBox(height: AppSpacing.sectionGap),
-                const SectionHeader(title: 'Enrolled courses', actionLabel: 'View all'),
-                EnrolledCoursesSection(summaries: MockCatalog.enrolledSummaries),
-                const SizedBox(height: AppSpacing.sectionGap),
-                const SectionHeader(title: 'Learning progress'),
-                _LearningProgressPlaceholder(scheme: scheme),
-                const SizedBox(height: AppSpacing.sectionGap),
-                const SectionHeader(title: 'Recent activity'),
-                RecentActivitySection(items: MockCatalog.recentActivity),
-                const SizedBox(height: AppSpacing.sectionGap),
-                const SectionHeader(title: 'Upcoming deadlines'),
-                DeadlinesSection(items: MockCatalog.deadlines),
-                const SizedBox(height: AppSpacing.sectionGap),
-                const SectionHeader(title: 'Quick actions'),
-                const QuickActionsGrid(),
-                const SizedBox(height: 88),
-              ],
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: IgnorePointer(
+            child: SizedBox(
+              width: double.infinity,
+              height: 280,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Image.network(
+                    _bottomBackgroundImageUrl,
+                    fit: BoxFit.cover,
+                    alignment: Alignment.bottomCenter,
+                    errorBuilder: (context, error, stackTrace) {
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          scheme.surface.withValues(alpha: 0.00),
+                          scheme.surface.withValues(alpha: 0.44),
+                          scheme.surface.withValues(alpha: 0.88),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
+        ),
+        CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.containerPadding,
+                  12,
+                  AppSpacing.containerPadding,
+                  18,
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CircleAvatar(
+                      radius: 20,
+                      backgroundColor: scheme.primaryContainer,
+                      child: Text(
+                        displayName.isNotEmpty
+                            ? displayName[0].toUpperCase()
+                            : '?',
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          color: scheme.onPrimaryContainer,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${MockCatalog.greeting},',
+                            style: Theme.of(context).textTheme.labelMedium
+                                ?.copyWith(
+                                  color: scheme.onSurfaceVariant,
+                                  letterSpacing: 0.8,
+                                ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            displayName,
+                            style: Theme.of(context).textTheme.titleLarge
+                                ?.copyWith(
+                                  fontWeight: FontWeight.w800,
+                                  color: scheme.onSurface,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          MockCatalog.brandTitle,
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                color: scheme.secondary,
+                                fontWeight: FontWeight.w900,
+                                letterSpacing: 1.2,
+                              ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Keep learning',
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(color: scheme.onSurfaceVariant),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(width: 8),
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(Icons.notifications_none_rounded),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: Divider(
+                    height: 1,
+                    thickness: 1.75,
+                    color: scheme.outlineVariant.withValues(alpha: 0.42),
+                  ),
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 14)),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.containerPadding,
+              ),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    _StreakHeroCard(days: MockCatalog.streakDays),
+                    const SizedBox(height: AppSpacing.stackGap),
+                    HomeAiCard(suggestion: MockCatalog.aiSuggestion),
+                    const SizedBox(height: AppSpacing.sectionGap),
+                    const SectionHeader(
+                      title: 'Enrolled courses',
+                      actionLabel: 'View all',
+                    ),
+                    EnrolledCoursesSection(
+                      summaries: MockCatalog.enrolledSummaries,
+                    ),
+                    const SizedBox(height: AppSpacing.sectionGap),
+                    const SectionHeader(title: 'Learning progress'),
+                    _LearningProgressChart(scheme: scheme),
+                    const SizedBox(height: AppSpacing.sectionGap),
+                    const SectionHeader(title: 'Recent activity'),
+                    RecentActivitySection(items: MockCatalog.recentActivity),
+                    const SizedBox(height: AppSpacing.sectionGap),
+                    const SectionHeader(title: 'Upcoming deadlines'),
+                    DeadlinesSection(items: MockCatalog.deadlines),
+                    const SizedBox(height: AppSpacing.sectionGap),
+                    const SectionHeader(title: 'Quick actions'),
+                    const QuickActionsGrid(),
+                    const SizedBox(height: 88),
+                  ],
+                ),
+              ),
+            ),
+          ],
         ),
       ],
     );
   }
 }
 
-class _LearningProgressPlaceholder extends StatelessWidget {
-  const _LearningProgressPlaceholder({required this.scheme});
+class _StreakHeroCard extends StatelessWidget {
+  const _StreakHeroCard({required this.days});
+
+  final int days;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      constraints: const BoxConstraints(minHeight: 188),
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            scheme.primaryContainer.withValues(alpha: 0.84),
+            scheme.secondaryContainer.withValues(alpha: 0.74),
+            scheme.surfaceContainerHigh.withValues(alpha: 0.90),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: scheme.primary.withValues(alpha: 0.14)),
+        boxShadow: [
+          BoxShadow(
+            color: scheme.primary.withValues(alpha: 0.08),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 54,
+                height: 54,
+                decoration: BoxDecoration(
+                  color: scheme.primary.withValues(alpha: 0.16),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.local_fire_department_rounded,
+                  color: scheme.primary,
+                  size: 28,
+                ),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '$days day streak',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: scheme.onSurface,
+                        fontWeight: FontWeight.w900,
+                        letterSpacing: 0.2,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'You have studied every day this week. Keep the momentum and extend it tonight.',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                        height: 1.35,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        _StreakInfoChip(
+                          label: 'Today',
+                          value: '2 sessions',
+                          scheme: scheme,
+                        ),
+                        _StreakInfoChip(
+                          label: 'Best run',
+                          value: '11 days',
+                          scheme: scheme,
+                        ),
+                        _StreakInfoChip(
+                          label: 'Reward',
+                          value: '+120 XP',
+                          scheme: scheme,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: LinearProgressIndicator(
+                  value: 0.84,
+                  minHeight: 7,
+                  borderRadius: BorderRadius.circular(999),
+                  backgroundColor: scheme.surface.withValues(alpha: 0.18),
+                  valueColor: AlwaysStoppedAnimation<Color>(scheme.primary),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                'Streak goal 84%',
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: scheme.primary,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StreakInfoChip extends StatelessWidget {
+  const _StreakInfoChip({
+    required this.label,
+    required this.value,
+    required this.scheme,
+  });
+
+  final String label;
+  final String value;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHigh.withValues(alpha: 0.72),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.28),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.labelSmall?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: scheme.onSurface,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LearningProgressChart extends StatelessWidget {
+  const _LearningProgressChart({required this.scheme});
 
   final ColorScheme scheme;
 
   @override
   Widget build(BuildContext context) {
     const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    final values = <double>[0.35, 0.55, 0.42, 0.9, 0.64, 0.78, 0.5];
+
     return Container(
-      height: 140,
-      padding: const EdgeInsets.all(16),
+      height: 234,
+      padding: const EdgeInsets.all(18),
       decoration: BoxDecoration(
-        color: scheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: scheme.outlineVariant.withValues(alpha: 0.35)),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            scheme.surfaceContainerHighest.withValues(alpha: 0.90),
+            scheme.surfaceContainerLow.withValues(alpha: 0.78),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.28),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: scheme.shadow.withValues(alpha: 0.06),
+            blurRadius: 16,
+            offset: const Offset(0, 8),
+          ),
+        ],
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.end,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (var i = 0; i < days.length; i++)
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 2),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    Container(
-                      height: 24.0 + (i % 4) * 18,
-                      decoration: BoxDecoration(
-                        color: i == 3 ? scheme.primary : scheme.surfaceContainerHigh,
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      days[i],
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                            color: i == 3 ? scheme.primary : scheme.onSurfaceVariant,
-                            fontWeight: i == 3 ? FontWeight.w700 : FontWeight.w500,
-                          ),
-                    ),
-                  ],
+          Row(
+            children: [
+              Icon(Icons.insights_rounded, color: scheme.primary, size: 18),
+              const SizedBox(width: 8),
+              Text(
+                'Weekly learning trend',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w800,
+                  color: scheme.onSurface,
                 ),
               ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'A quick look at your learning rhythm this week.',
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+          const SizedBox(height: 18),
+          Expanded(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                for (var i = 0; i < days.length; i++)
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 3),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          Expanded(
+                            child: Align(
+                              alignment: Alignment.bottomCenter,
+                              child: FractionallySizedBox(
+                                heightFactor: values[i],
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    gradient: LinearGradient(
+                                      begin: Alignment.topCenter,
+                                      end: Alignment.bottomCenter,
+                                      colors: i == 3
+                                          ? [scheme.primary, scheme.secondary]
+                                          : [
+                                              scheme.surfaceContainerHigh,
+                                              scheme.surfaceContainerHighest,
+                                            ],
+                                    ),
+                                    borderRadius: BorderRadius.circular(10),
+                                    boxShadow: i == 3
+                                        ? [
+                                            BoxShadow(
+                                              color: scheme.primary.withValues(
+                                                alpha: 0.22,
+                                              ),
+                                              blurRadius: 12,
+                                              offset: const Offset(0, 6),
+                                            ),
+                                          ]
+                                        : null,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            days[i],
+                            style: Theme.of(context).textTheme.labelSmall
+                                ?.copyWith(
+                                  color: i == 3
+                                      ? scheme.primary
+                                      : scheme.onSurfaceVariant,
+                                  fontWeight: i == 3
+                                      ? FontWeight.w800
+                                      : FontWeight.w500,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
             ),
+          ),
         ],
       ),
     );

--- a/apps/mobile/lib/features/home/presentation/widgets/enrolled_courses_section.dart
+++ b/apps/mobile/lib/features/home/presentation/widgets/enrolled_courses_section.dart
@@ -22,6 +22,7 @@ class EnrolledCoursesSection extends StatelessWidget {
           final s = summaries[i];
           final course = MockCatalog.courseById(s.courseId);
           final title = course?.name ?? 'Course';
+          final subtitle = course?.code ?? 'Course code';
           return SizedBox(
             width: 220,
             child: Container(

--- a/apps/mobile/lib/features/shell/presentation/main_shell_screen.dart
+++ b/apps/mobile/lib/features/shell/presentation/main_shell_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mobile/core/widgets/widgets.dart';
 
 class MainShellScreen extends StatelessWidget {
   const MainShellScreen({super.key, required this.navigationShell});
@@ -18,7 +19,12 @@ class MainShellScreen extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      body: navigationShell,
+      body: Column(
+        children: [
+          const AppHeader(),
+          Expanded(child: navigationShell),
+        ],
+      ),
       bottomNavigationBar: SafeArea(
         top: false,
         child: Padding(

--- a/apps/mobile/lib/features/shell/presentation/main_shell_screen.dart
+++ b/apps/mobile/lib/features/shell/presentation/main_shell_screen.dart
@@ -19,38 +19,197 @@ class MainShellScreen extends StatelessWidget {
 
     return Scaffold(
       body: navigationShell,
-      floatingActionButton: FloatingActionButton.large(
-        onPressed: () {},
-        backgroundColor: scheme.primaryContainer,
-        foregroundColor: scheme.onPrimaryContainer,
-        child: const Icon(Icons.auto_awesome),
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: scheme.surfaceContainerHigh.withValues(alpha: 0.92),
+              borderRadius: BorderRadius.circular(28),
+              border: Border.all(
+                color: scheme.outlineVariant.withValues(alpha: 0.28),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: scheme.shadow.withValues(alpha: 0.12),
+                  blurRadius: 24,
+                  offset: const Offset(0, 10),
+                ),
+              ],
+            ),
+            child: Row(
+              children: [
+                _ShellDestination(
+                  icon: Icons.home_outlined,
+                  selectedIcon: Icons.home_rounded,
+                  label: 'Home',
+                  selected: navigationShell.currentIndex == 0,
+                  onTap: () => _onDestinationSelected(0),
+                ),
+                _ShellDestination(
+                  icon: Icons.menu_book_outlined,
+                  selectedIcon: Icons.menu_book,
+                  label: 'Courses',
+                  selected: navigationShell.currentIndex == 1,
+                  onTap: () => _onDestinationSelected(1),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: _AiNavButton(scheme: scheme, onTap: () {}),
+                  ),
+                ),
+                _ShellDestination(
+                  icon: Icons.bar_chart_outlined,
+                  selectedIcon: Icons.bar_chart,
+                  label: 'Stats',
+                  selected: navigationShell.currentIndex == 2,
+                  onTap: () => _onDestinationSelected(2),
+                ),
+                _ShellDestination(
+                  icon: Icons.person_outline,
+                  selectedIcon: Icons.person,
+                  label: 'Profile',
+                  selected: navigationShell.currentIndex == 3,
+                  onTap: () => _onDestinationSelected(3),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: _onDestinationSelected,
-        destinations: [
-          NavigationDestination(
-            icon: Icon(Icons.home_outlined, color: scheme.onSurfaceVariant),
-            selectedIcon: Icon(Icons.home_rounded, color: scheme.secondary),
-            label: 'Home',
+    );
+  }
+}
+
+class _ShellDestination extends StatelessWidget {
+  const _ShellDestination({
+    required this.icon,
+    required this.selectedIcon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final IconData selectedIcon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Expanded(
+      child: InkResponse(
+        onTap: onTap,
+        radius: 24,
+        child: Padding(
+          padding: EdgeInsets.zero,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 180),
+                curve: Curves.easeOut,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 5,
+                ),
+                decoration: BoxDecoration(
+                  color: selected
+                      ? scheme.primary.withValues(alpha: 0.12)
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(
+                    color: selected
+                        ? scheme.primary.withValues(alpha: 0.18)
+                        : Colors.transparent,
+                  ),
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      selected ? selectedIcon : icon,
+                      size: 20,
+                      color: selected
+                          ? scheme.primary
+                          : scheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      label,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: selected
+                            ? scheme.primary
+                            : scheme.onSurfaceVariant,
+                        fontWeight: selected
+                            ? FontWeight.w800
+                            : FontWeight.w500,
+                        letterSpacing: selected ? 0.3 : 0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
-          NavigationDestination(
-            icon: Icon(Icons.menu_book_outlined, color: scheme.onSurfaceVariant),
-            selectedIcon: Icon(Icons.menu_book, color: scheme.secondary),
-            label: 'Courses',
+        ),
+      ),
+    );
+  }
+}
+
+class _AiNavButton extends StatelessWidget {
+  const _AiNavButton({required this.scheme, required this.onTap});
+
+  final ColorScheme scheme;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          height: 40,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [scheme.primary, scheme.secondary],
+            ),
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: scheme.primary.withValues(alpha: 0.18),
+                blurRadius: 18,
+                offset: const Offset(0, 8),
+              ),
+            ],
           ),
-          NavigationDestination(
-            icon: Icon(Icons.bar_chart_outlined, color: scheme.onSurfaceVariant),
-            selectedIcon: Icon(Icons.bar_chart, color: scheme.secondary),
-            label: 'Stats',
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.auto_awesome, color: scheme.onPrimary, size: 18),
+              const SizedBox(height: 0),
+              Text(
+                'AI',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: scheme.onPrimary,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0.8,
+                ),
+              ),
+            ],
           ),
-          NavigationDestination(
-            icon: Icon(Icons.person_outline, color: scheme.onSurfaceVariant),
-            selectedIcon: Icon(Icons.person, color: scheme.secondary),
-            label: 'Profile',
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/features/stats/presentation/stats_screen.dart
+++ b/apps/mobile/lib/features/stats/presentation/stats_screen.dart
@@ -1,37 +1,261 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
 
+import 'package:flutter/material.dart';
+import 'package:mobile/core/testing/mock_catalog.dart';
+import 'package:mobile/theme/app_radii.dart';
 import 'package:mobile/theme/app_spacing.dart';
 
 class StatsScreen extends StatelessWidget {
   const StatsScreen({super.key});
 
+  static const _bottomBackgroundImageUrl =
+      'https://lh3.googleusercontent.com/aida-public/AB6AXuB8eEmwxGtwcZGuL78pXL9F0XDxuX3q6KfZUCJdg2R2Z4DGNAfqI5P0o3JMNlGcjljZX0xrScWv5bE_7oSNOfmsnqzY6kQSF71qfYoSJUT-MfRlBxz9b-K1-IV8CSZLu1eCgE2h4mnFS7-HppKZ_NvF6UAjj4Gcop51PKeZI1aY-scIILL8smc6-Ywq8H1hcYh2twu2x6Tv3RPGTYDSd0PVGuX4exp7hPoc6C5wAE9aPYqHSwvBdBWIVXsYNWq3-pm0Zup2Oo577RJm';
+
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: const EdgeInsets.all(AppSpacing.containerPadding),
-      children: [
-        Text('Stats', style: Theme.of(context).textTheme.headlineMedium),
-        const SizedBox(height: 12),
-        Text(
-          'Study time, completion rates, and streaks will connect to the API later.',
-          style: Theme.of(context).textTheme.bodyMedium,
-        ),
-        const SizedBox(height: 24),
-        _PlaceholderCard(title: 'This week', value: '12.4 h'),
-        const SizedBox(height: 12),
-        _PlaceholderCard(title: 'Quizzes passed', value: '8'),
-        const SizedBox(height: 12),
-        _PlaceholderCard(title: 'Avg. score', value: '87%'),
-      ],
+    final scheme = Theme.of(context).colorScheme;
+    final summaries = MockCatalog.enrolledSummaries;
+    final totalProgress = summaries.isEmpty
+        ? 0
+        : (summaries.fold<int>(0, (sum, item) => sum + item.progressPercent) /
+                  summaries.length)
+              .round();
+    final totalModulesDone = summaries.fold<int>(
+      0,
+      (sum, item) => sum + item.modulesDone,
     );
+    final totalModules = summaries.fold<int>(
+      0,
+      (sum, item) => sum + item.modulesTotal,
+    );
+    final remainingModules = totalModules - totalModulesDone;
+    final totalStudyHours = 18.6;
+    final weeklyMinutes = <double>[32, 46, 28, 58, 64, 40, 52];
+
+    final courseRows = summaries.map((summary) {
+      final course = MockCatalog.courseById(summary.courseId);
+      return _CourseMomentumRow(
+        title: course?.name ?? 'Course ${summary.courseId}',
+        code: course?.code ?? 'N/A',
+        progress: summary.progressPercent / 100,
+        modulesDone: summary.modulesDone,
+        modulesTotal: summary.modulesTotal,
+        accent: _accentForCode(summary.courseId, scheme),
+      );
+    }).toList();
+
+    final activityBreakdown = <_ActivitySlice>[
+      _ActivitySlice(label: 'Videos', value: 42, color: scheme.primary),
+      _ActivitySlice(label: 'Notes', value: 28, color: scheme.secondary),
+      _ActivitySlice(label: 'Quizzes', value: 18, color: scheme.tertiary),
+      _ActivitySlice(label: 'Labs', value: 12, color: scheme.error),
+    ];
+
+    final topCourse = summaries.isNotEmpty
+        ? summaries.reduce(
+            (a, b) => a.progressPercent >= b.progressPercent ? a : b,
+          )
+        : null;
+    final topCourseModel = topCourse == null
+        ? null
+        : MockCatalog.courseById(topCourse.courseId);
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  scheme.surface,
+                  scheme.surface.withValues(alpha: 0.96),
+                  scheme.surfaceContainerLowest,
+                ],
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: IgnorePointer(
+              child: SizedBox(
+                width: double.infinity,
+                height: 280,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Image.network(
+                      _bottomBackgroundImageUrl,
+                      fit: BoxFit.cover,
+                      alignment: Alignment.bottomCenter,
+                      filterQuality: FilterQuality.low,
+                      errorBuilder: (context, error, stackTrace) {
+                        return const SizedBox.shrink();
+                      },
+                    ),
+                    ClipRect(
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+                        child: const SizedBox.expand(),
+                      ),
+                    ),
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            scheme.surface.withValues(alpha: 0.00),
+                            scheme.surface.withValues(alpha: 0.58),
+                            scheme.surface.withValues(alpha: 0.90),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          SafeArea(
+            bottom: false,
+            child: CustomScrollView(
+              slivers: [
+                const SliverToBoxAdapter(child: SizedBox(height: 12)),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.containerPadding,
+                  ),
+                  sliver: SliverToBoxAdapter(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _StatsHeroCard(
+                          totalProgress: totalProgress,
+                          streakDays: MockCatalog.streakDays,
+                          activeCourses: summaries.length,
+                          totalStudyHours: totalStudyHours,
+                          topCourseTitle:
+                              topCourseModel?.name ?? 'No course spotlight',
+                          topCourseProgress: topCourse?.progressPercent ?? 0,
+                        ),
+                        const SizedBox(height: AppSpacing.stackGap),
+                        _SectionCard(
+                          title: 'This week momentum',
+                          subtitle:
+                              'A quick view of your study rhythm across the last seven days.',
+                          child: _WeeklyBarChart(values: weeklyMinutes),
+                        ),
+                        const SizedBox(height: AppSpacing.stackGap),
+                        _SectionCard(
+                          title: 'Course momentum',
+                          subtitle:
+                              'Your strongest courses based on completion and module progress.',
+                          child: Column(
+                            children: [
+                              for (var i = 0; i < courseRows.length; i++) ...[
+                                courseRows[i],
+                                if (i != courseRows.length - 1)
+                                  const SizedBox(height: 14),
+                              ],
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.stackGap),
+                        _SectionCard(
+                          title: 'Engagement split',
+                          subtitle:
+                              'How your study time is currently distributed.',
+                          child: _ActivityBreakdownChart(
+                            slices: activityBreakdown,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.stackGap),
+                        _SectionCard(
+                          title: 'Performance snapshot',
+                          subtitle:
+                              'Pulling together the most useful indicators from the dashboard and course details.',
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: Row(
+                              children: [
+                                _MetricTile(
+                                  width: 176,
+                                  height: 156,
+                                  label: 'Avg. completion',
+                                  value: '$totalProgress%',
+                                  helper: 'Across active courses',
+                                  icon: Icons.insights_rounded,
+                                  accent: scheme.primary,
+                                ),
+                                const SizedBox(width: 12),
+                                _MetricTile(
+                                  width: 176,
+                                  height: 156,
+                                  label: 'Modules completed',
+                                  value: '$totalModulesDone',
+                                  helper: 'Out of $totalModules total',
+                                  icon: Icons.check_circle_outline_rounded,
+                                  accent: scheme.secondary,
+                                ),
+                                const SizedBox(width: 12),
+                                _MetricTile(
+                                  width: 176,
+                                  height: 156,
+                                  label: 'Remaining modules',
+                                  value: '$remainingModules',
+                                  helper: 'Keep the momentum going',
+                                  icon: Icons.timelapse_rounded,
+                                  accent: scheme.tertiary,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 96),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _accentForCode(String id, ColorScheme scheme) {
+    final palette = [
+      scheme.primary,
+      scheme.secondary,
+      scheme.tertiary,
+      scheme.error,
+    ];
+    final index = id.codeUnits.fold<int>(0, (sum, unit) => sum + unit);
+    return palette[index % palette.length];
   }
 }
 
-class _PlaceholderCard extends StatelessWidget {
-  const _PlaceholderCard({required this.title, required this.value});
+class _StatsHeroCard extends StatelessWidget {
+  const _StatsHeroCard({
+    required this.totalProgress,
+    required this.streakDays,
+    required this.activeCourses,
+    required this.totalStudyHours,
+    required this.topCourseTitle,
+    required this.topCourseProgress,
+  });
 
-  final String title;
-  final String value;
+  final int totalProgress;
+  final int streakDays;
+  final int activeCourses;
+  final double totalStudyHours;
+  final String topCourseTitle;
+  final int topCourseProgress;
 
   @override
   Widget build(BuildContext context) {
@@ -39,14 +263,664 @@ class _PlaceholderCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: scheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: scheme.outlineVariant.withValues(alpha: 0.35)),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            scheme.primaryContainer.withValues(alpha: 0.92),
+            scheme.secondaryContainer.withValues(alpha: 0.80),
+            scheme.surfaceContainerHighest.withValues(alpha: 0.86),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(AppRadii.xl),
+        border: Border.all(color: scheme.primary.withValues(alpha: 0.10)),
+        boxShadow: [
+          BoxShadow(
+            color: scheme.shadow.withValues(alpha: 0.10),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Analytics dashboard',
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: scheme.onSurfaceVariant,
+              letterSpacing: 1.1,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '$totalProgress%',
+                      style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                        color: scheme.onSurface,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Average course progress across your active workload.',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        _HeroPill(
+                          label: '$streakDays-day streak',
+                          icon: Icons.local_fire_department_rounded,
+                        ),
+                        _HeroPill(
+                          label: '$activeCourses active courses',
+                          icon: Icons.menu_book_rounded,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              SizedBox(
+                width: 112,
+                height: 112,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    SizedBox(
+                      width: 112,
+                      height: 112,
+                      child: CircularProgressIndicator(
+                        value: totalProgress / 100,
+                        strokeWidth: 10,
+                        strokeCap: StrokeCap.round,
+                        backgroundColor: scheme.surface.withValues(alpha: 0.24),
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          scheme.primary,
+                        ),
+                      ),
+                    ),
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          '$totalProgress%',
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(
+                                color: scheme.onSurface,
+                                fontWeight: FontWeight.w900,
+                              ),
+                        ),
+                        Text(
+                          'overall',
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(color: scheme.onSurfaceVariant),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          Row(
+            children: [
+              Expanded(
+                child: _MiniStat(
+                  label: 'Study hours',
+                  value: '${totalStudyHours.toStringAsFixed(1)}h',
+                  icon: Icons.schedule_rounded,
+                  accent: scheme.primary,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _MiniStat(
+                  label: 'Spotlight course',
+                  value: topCourseTitle,
+                  icon: Icons.rocket_launch_rounded,
+                  accent: scheme.secondary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(AppRadii.full),
+            child: LinearProgressIndicator(
+              value: topCourseProgress / 100,
+              minHeight: 8,
+              backgroundColor: scheme.surface.withValues(alpha: 0.18),
+              valueColor: AlwaysStoppedAnimation<Color>(scheme.primary),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '$topCourseProgress% completion in your most advanced course.',
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroPill extends StatelessWidget {
+  const _HeroPill({required this.label, required this.icon});
+
+  final String label;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: scheme.surface.withValues(alpha: 0.42),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.22),
+        ),
       ),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(child: Text(title, style: Theme.of(context).textTheme.titleSmall)),
-          Text(value, style: Theme.of(context).textTheme.headlineSmall),
+          Icon(icon, size: 16, color: scheme.primary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: scheme.onSurface,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest.withValues(alpha: 0.84),
+        borderRadius: BorderRadius.circular(AppRadii.xl),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.24),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: scheme.onSurfaceVariant,
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _WeeklyBarChart extends StatelessWidget {
+  const _WeeklyBarChart({required this.values});
+
+  final List<double> values;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    const labels = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+    final maxValue = values.reduce((a, b) => a > b ? a : b);
+
+    return SizedBox(
+      height: 170,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: List.generate(values.length, (index) {
+          final heightFactor = values[index] / maxValue;
+          return Expanded(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: index == 0 ? 0 : 4),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Text(
+                    '${values[index].round()}m',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 250),
+                    height: 110 * heightFactor,
+                    width: double.infinity,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [scheme.primary, scheme.secondary],
+                      ),
+                      borderRadius: BorderRadius.circular(18),
+                      boxShadow: [
+                        BoxShadow(
+                          color: scheme.primary.withValues(alpha: 0.18),
+                          blurRadius: 18,
+                          offset: const Offset(0, 8),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    labels[index],
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _CourseMomentumRow extends StatelessWidget {
+  const _CourseMomentumRow({
+    required this.title,
+    required this.code,
+    required this.progress,
+    required this.modulesDone,
+    required this.modulesTotal,
+    required this.accent,
+  });
+
+  final String title;
+  final String code;
+  final double progress;
+  final int modulesDone;
+  final int modulesTotal;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: scheme.surface.withValues(alpha: 0.42),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.18),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 42,
+                height: 42,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      accent.withValues(alpha: 0.92),
+                      accent.withValues(alpha: 0.65),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: const Icon(
+                  Icons.menu_book_rounded,
+                  color: Colors.white,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      code,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Text(
+                '${(progress * 100).round()}%',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: accent,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 10,
+              backgroundColor: scheme.surfaceContainerHighest.withValues(
+                alpha: 0.84,
+              ),
+              valueColor: AlwaysStoppedAnimation<Color>(accent),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '$modulesDone of $modulesTotal modules completed',
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActivitySlice {
+  const _ActivitySlice({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final int value;
+  final Color color;
+}
+
+class _ActivityBreakdownChart extends StatelessWidget {
+  const _ActivityBreakdownChart({required this.slices});
+
+  final List<_ActivitySlice> slices;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final total = slices.fold<int>(0, (sum, item) => sum + item.value);
+
+    return Column(
+      children: [
+        SizedBox(
+          height: 170,
+          child: Row(
+            children: [
+              Expanded(
+                flex: 42,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(24),
+                  child: Container(
+                    color: scheme.surfaceContainerHigh.withValues(alpha: 0.56),
+                    child: Column(
+                      children: [
+                        for (final slice in slices)
+                          Expanded(
+                            flex: slice.value,
+                            child: Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.centerLeft,
+                                  end: Alignment.centerRight,
+                                  colors: [
+                                    slice.color.withValues(alpha: 0.95),
+                                    slice.color.withValues(alpha: 0.70),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                flex: 58,
+                child: Column(
+                  children: [
+                    for (final slice in slices) ...[
+                      Expanded(
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 12,
+                              height: 12,
+                              decoration: BoxDecoration(
+                                color: slice.color,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: Text(
+                                slice.label,
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(fontWeight: FontWeight.w700),
+                              ),
+                            ),
+                            Text(
+                              '${((slice.value / total) * 100).round()}%',
+                              style: Theme.of(context).textTheme.labelLarge
+                                  ?.copyWith(
+                                    color: slice.color,
+                                    fontWeight: FontWeight.w900,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        Text(
+          'Total tracked activity: $total%',
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({
+    required this.width,
+    required this.height,
+    required this.label,
+    required this.value,
+    required this.helper,
+    required this.icon,
+    required this.accent,
+  });
+
+  final double width;
+  final double height;
+  final String label;
+  final String value;
+  final String helper;
+  final IconData icon;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              accent.withValues(alpha: 0.14),
+              scheme.surfaceContainerHigh.withValues(alpha: 0.72),
+            ],
+          ),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: accent.withValues(alpha: 0.14)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(icon, color: accent, size: 18),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              value,
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w900),
+            ),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: scheme.onSurfaceVariant,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            Text(
+              helper,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: scheme.onSurfaceVariant,
+                height: 1.25,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniStat extends StatelessWidget {
+  const _MiniStat({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.accent,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.surface.withValues(alpha: 0.42),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.16),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: accent, size: 18),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(
+              context,
+            ).textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w900),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            label,
+            style: Theme.of(
+              context,
+            ).textTheme.labelSmall?.copyWith(color: scheme.onSurfaceVariant),
+          ),
         ],
       ),
     );

--- a/apps/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,0 +1,12 @@
+//
+//  Generated file. Do not edit.
+//
+
+import FlutterMacOS
+import Foundation
+
+import shared_preferences_foundation
+
+func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+}

--- a/apps/mobile/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
+++ b/apps/mobile/macos/Flutter/ephemeral/Flutter-Generated.xcconfig
@@ -1,0 +1,12 @@
+// This is a generated file; do not edit or check into version control.
+FLUTTER_ROOT=C:\Users\hp\develop\flutter
+FLUTTER_APPLICATION_PATH=D:\UniLearn\UniLearn\apps\mobile
+FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=D:\UniLearn\UniLearn\apps\mobile\macos\Flutter\ephemeral\Packages\.packages\FlutterFramework
+COCOAPODS_PARALLEL_CODE_SIGN=true
+FLUTTER_BUILD_DIR=build
+FLUTTER_BUILD_NAME=1.0.0
+FLUTTER_BUILD_NUMBER=1
+DART_OBFUSCATION=false
+TRACK_WIDGET_CREATION=true
+TREE_SHAKE_ICONS=false
+PACKAGE_CONFIG=.dart_tool/package_config.json

--- a/apps/mobile/macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+++ b/apps/mobile/macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+// Generated file. Do not edit.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "FlutterGeneratedPluginSwiftPackage",
+    platforms: [
+        .macOS("10.15")
+    ],
+    products: [
+        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+    ],
+    dependencies: [
+        
+    ],
+    targets: [
+        .target(
+            name: "FlutterGeneratedPluginSwiftPackage"
+        )
+    ]
+)

--- a/apps/mobile/macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Sources/FlutterGeneratedPluginSwiftPackage/FlutterGeneratedPluginSwiftPackage.swift
+++ b/apps/mobile/macos/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Sources/FlutterGeneratedPluginSwiftPackage/FlutterGeneratedPluginSwiftPackage.swift
@@ -1,0 +1,3 @@
+//
+// Generated file. Do not edit.
+//

--- a/apps/mobile/macos/Flutter/ephemeral/flutter_export_environment.sh
+++ b/apps/mobile/macos/Flutter/ephemeral/flutter_export_environment.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=C:\Users\hp\develop\flutter"
+export "FLUTTER_APPLICATION_PATH=D:\UniLearn\UniLearn\apps\mobile"
+export "FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=D:\UniLearn\UniLearn\apps\mobile\macos\Flutter\ephemeral\Packages\.packages\FlutterFramework"
+export "COCOAPODS_PARALLEL_CODE_SIGN=true"
+export "FLUTTER_BUILD_DIR=build"
+export "FLUTTER_BUILD_NAME=1.0.0"
+export "FLUTTER_BUILD_NUMBER=1"
+export "DART_OBFUSCATION=false"
+export "TRACK_WIDGET_CREATION=true"
+export "TREE_SHAKE_ICONS=false"
+export "PACKAGE_CONFIG=.dart_tool/package_config.json"

--- a/apps/mobile/macos/Flutter/ephemeral/flutter_native_integration.env
+++ b/apps/mobile/macos/Flutter/ephemeral/flutter_native_integration.env
@@ -1,0 +1,11 @@
+FLUTTER_ROOT=C:\Users\hp\develop\flutter
+FLUTTER_APPLICATION_PATH=D:\UniLearn\UniLearn\apps\mobile
+FLUTTER_FRAMEWORK_SWIFT_PACKAGE_PATH=D:\UniLearn\UniLearn\apps\mobile\macos\Flutter\ephemeral\Packages\.packages\FlutterFramework
+COCOAPODS_PARALLEL_CODE_SIGN=true
+FLUTTER_BUILD_DIR=build
+FLUTTER_BUILD_NAME=1.0.0
+FLUTTER_BUILD_NUMBER=1
+DART_OBFUSCATION=false
+TRACK_WIDGET_CREATION=true
+TREE_SHAKE_ICONS=false
+PACKAGE_CONFIG=.dart_tool/package_config.json

--- a/apps/mobile/web/index.html
+++ b/apps/mobile/web/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="UniLearn mobile app">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#0B1326">
+  <title>UniLearn</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>

--- a/apps/mobile/web/manifest.json
+++ b/apps/mobile/web/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "UniLearn",
+  "short_name": "UniLearn",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0B1326",
+  "theme_color": "#0B1326",
+  "description": "UniLearn mobile app",
+  "orientation": "portrait-primary",
+  "prefer_related_applications": false,
+  "icons": []
+}

--- a/apps/mobile/windows/flutter/ephemeral/generated_config.cmake
+++ b/apps/mobile/windows/flutter/ephemeral/generated_config.cmake
@@ -1,0 +1,24 @@
+# Generated code do not commit.
+file(TO_CMAKE_PATH "C:\\Users\\hp\\develop\\flutter" FLUTTER_ROOT)
+file(TO_CMAKE_PATH "D:\\UniLearn\\UniLearn\\apps\\mobile" PROJECT_DIR)
+
+set(FLUTTER_VERSION "1.0.0+1" PARENT_SCOPE)
+set(FLUTTER_VERSION_MAJOR 1 PARENT_SCOPE)
+set(FLUTTER_VERSION_MINOR 0 PARENT_SCOPE)
+set(FLUTTER_VERSION_PATCH 0 PARENT_SCOPE)
+set(FLUTTER_VERSION_BUILD 1 PARENT_SCOPE)
+
+# Environment variables to pass to tool_backend.sh
+list(APPEND FLUTTER_TOOL_ENVIRONMENT
+  "FLUTTER_ROOT=C:\\Users\\hp\\develop\\flutter"
+  "PROJECT_DIR=D:\\UniLearn\\UniLearn\\apps\\mobile"
+  "FLUTTER_ROOT=C:\\Users\\hp\\develop\\flutter"
+  "FLUTTER_EPHEMERAL_DIR=D:\\UniLearn\\UniLearn\\apps\\mobile\\windows\\flutter\\ephemeral"
+  "PROJECT_DIR=D:\\UniLearn\\UniLearn\\apps\\mobile"
+  "FLUTTER_TARGET=D:\\UniLearn\\UniLearn\\apps\\mobile\\lib\\main.dart"
+  "DART_DEFINES=RkxVVFRFUl9WRVJTSU9OPTMuNDQuMA==,RkxVVFRFUl9DSEFOTkVMPXN0YWJsZQ==,RkxVVFRFUl9HSVRfVVJMPWh0dHBzOi8vZ2l0aHViLmNvbS9mbHV0dGVyL2ZsdXR0ZXIuZ2l0,RkxVVFRFUl9GUkFNRVdPUktfUkVWSVNJT049NTU5ZmZhM2Y3NQ==,RkxVVFRFUl9FTkdJTkVfUkVWSVNJT049NGM1MjVkYWM1ZQ==,RkxVVFRFUl9EQVJUX1ZFUlNJT049My4xMi4w"
+  "DART_OBFUSCATION=false"
+  "TRACK_WIDGET_CREATION=true"
+  "TREE_SHAKE_ICONS=false"
+  "PACKAGE_CONFIG=D:\\UniLearn\\UniLearn\\apps\\mobile\\.dart_tool\\package_config.json"
+)


### PR DESCRIPTION
key changes
- Courses: Added modern top-year tags (includes "All"), removed per-card chips, client-side filtering by year.
- Header: Created shared AppHeader and integrated into the app shell.
- Course Detail: Removed filled notification icon; replaced Tabs with a growable Materials card; standardized material rows with a leading PDF icon and a trailing "View" button.
- Home & Course Detail backgrounds: Applied image-only blur to bottom background images while keeping foreground content sharp.
- Stats: Rebuilt as a modern analytics dashboard (hero cards, weekly bar chart, course momentum rows, activity breakdown); made performance snapshot horizontally scrollable with equal-sized tiles.

for the first commit key changes are:
- splash page rebuilt based on the design in stitch
- onboarding page rebuild to match the design
- edited the registration and login page
- rebuild the course details page to match the stitch design.